### PR TITLE
build: Bake git hash version into the service docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           command: |
             if [ -z "${CIRCLE_TAG}" -a "${CIRCLE_BRANCH}" == "master" ]; then
               sudo apt-get -y -qq install awscli
-              aws s3 cp build/bootstrap/ s3://weaveworks-launcher/bootstrap/$(echo $CIRCLE_SHA1 | cut -c -8)/ --recursive
+              aws s3 cp build/bootstrap/ s3://weaveworks-launcher/bootstrap/${CIRCLE_SHA1}/ --recursive
             fi
 
   service:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /cache
+/docker/Dockerfile.service
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,17 @@ AGENT_DEPS   := $(call godeps,./agent)
 BOOTSTRAP_DEPS := $(call godeps,./bootstrap)
 SERVICE_DEPS := $(call godeps,./service)
 
+GIT_HASH :=$(shell git rev-parse HEAD)
 IMAGE_TAG:=$(shell ./docker/image-tag)
 
 all: agent bootstrap service
 agent: build/.agent.done
 bootstrap: build/.bootstrap.done
 service: build/.service.done
+
+docker/Dockerfile.service: docker/Dockerfile.service.in Makefile
+	@echo Generating $@
+	@sed -e 's/@@GIT_HASH@@/$(GIT_HASH)/g' < $< > $@.tmp && mv $@.tmp $@
 
 build/.%.done: docker/Dockerfile.%
 	mkdir -p ./build/docker/$*

--- a/docker/Dockerfile.service.in
+++ b/docker/Dockerfile.service.in
@@ -3,4 +3,4 @@ MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /
 COPY service /launcher-service
 EXPOSE 80
-ENTRYPOINT ["/launcher-service", "--bootstrap-version=5d95af2"]
+ENTRYPOINT ["/launcher-service", "--bootstrap-version=@@GIT_HASH@@"]


### PR DESCRIPTION
We want to be able to rollout images and rollout the bootstrap version we serve
when doing it.

To do so, we give the bootstrap hash as parameter to service as an argument in
the docker image (and not, say, in a kubernetes manifest). Bake the current
HEAD into that Dockerfile.service, generating it at build time.