### PR TITLE
agent: Find latest revision by iterating over all replica sets

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -58,21 +58,23 @@ func updateAgents(agentPollURL, wcPollURL string, agentCtx agentContext, kubeCli
 	// Self-update
 	log.Info("Updating self from ", agentPollURL)
 
-	initialRevision, err := k8s.GetDeploymentReplicaSetRevision(kubeClient, "weave", "weave-agent")
+	initialRevision, err := k8s.GetLatestDeploymentReplicaSetRevision(kubeClient, "weave", "weave-agent")
 	if err != nil {
 		logError("Failed to fetch latest deployment replicateset revision", err, agentCtx)
 		return
 	}
+	log.Info("Revision before self-update: ", initialRevision)
 	_, err = kubectl.Execute("apply", "-f", agentPollURL)
 	if err != nil {
 		logError("Failed to execute kubectl apply", err, agentCtx)
 		return
 	}
-	updatedRevision, err := k8s.GetDeploymentReplicaSetRevision(kubeClient, "weave", "weave-agent")
+	updatedRevision, err := k8s.GetLatestDeploymentReplicaSetRevision(kubeClient, "weave", "weave-agent")
 	if err != nil {
 		logError("Failed to fetch latest deployment replicateset revision", err, agentCtx)
 		return
 	}
+	log.Info("Revision after self-update: ", updatedRevision)
 
 	// If the agent replica set is updating, we will be killed via SIGTERM.
 	// The agent uses a RollingUpdate strategy, so we are only killed when the

--- a/pkg/k8s/deployments.go
+++ b/pkg/k8s/deployments.go
@@ -8,8 +8,9 @@ import (
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 )
 
-// GetDeploymentReplicaSetRevision gets the revision of the latest replica set of a deployment
-func GetDeploymentReplicaSetRevision(kubeClient *kubeclient.Clientset, namespace, name string) (int64, error) {
+// GetLatestDeploymentReplicaSetRevision gets the latest revision of replica sets of a deployment
+func GetLatestDeploymentReplicaSetRevision(kubeClient *kubeclient.Clientset, namespace, name string) (int64, error) {
+	// Based on https://github.com/kubernetes/kubernetes/blob/release-1.9/pkg/kubectl/history.go
 	versionedClient := kubeClient.ExtensionsV1beta1()
 
 	deployment, err := versionedClient.Deployments(namespace).Get(name, metav1.GetOptions{})
@@ -17,16 +18,25 @@ func GetDeploymentReplicaSetRevision(kubeClient *kubeclient.Clientset, namespace
 		return 0, fmt.Errorf("failed to retrieve deployment: %s", err)
 	}
 
-	_, oldRs, newRs, err := deploymentutil.GetAllReplicaSets(deployment, versionedClient)
+	_, allOldRSs, newRS, err := deploymentutil.GetAllReplicaSets(deployment, versionedClient)
 	if err != nil {
 		return 0, fmt.Errorf("failed to retrieve deployment replicasets: %s", err)
 	}
-
-	rs := deploymentutil.FindActiveOrLatest(newRs, oldRs)
-	revision, err := deploymentutil.Revision(rs)
-	if err != nil {
-		return 0, fmt.Errorf("failed to retrieve deployment replicaset revision: %s", err)
+	allRSs := allOldRSs
+	if newRS != nil {
+		allRSs = append(allRSs, newRS)
 	}
 
-	return revision, nil
+	var maxRevision int64
+	for _, rs := range allRSs {
+		v, err := deploymentutil.Revision(rs)
+		if err != nil {
+			continue
+		}
+		if v > maxRevision {
+			maxRevision = v
+		}
+	}
+
+	return maxRevision, nil
 }


### PR DESCRIPTION
`FindActiveOrLatest()` can return nil, which panics the line below (`Revision()`).
This issue is described here: https://github.com/weaveworks/launcher/issues/44

However, we are interested in the latest revision - not the active replica set.

Use logic based on https://github.com/kubernetes/kubernetes/blob/release-1.9/pkg/kubectl/history.go to get the latest revision.

Fixes #44 