### PR TITLE
service: Change prometheus namespace to service

### DIFF
--- a/service/main.go
+++ b/service/main.go
@@ -26,7 +26,7 @@ func main() {
 		hostname         = flag.String("hostname", "get.weave.works", "Hostname for external launcher service")
 		scheme           = flag.String("scheme", "https", "URL scheme for external launcher service")
 		serverCfg        = server.Config{
-			MetricsNamespace:        "launcher",
+			MetricsNamespace:        "service",
 			RegisterInstrumentation: true,
 		}
 	)


### PR DESCRIPTION
Change the prometheus namespace to service so we can plug into other WC service dashboards/alerts.

Changes `launcher_request_duration_seconds_...` 
to `service_request_duration_seconds_...{job="default/launcher-service"}`

Note that `service` goes throught authfe either way.