### PR TITLE
agent: Use git version instead of major and minor

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -160,7 +160,7 @@ func main() {
 	}
 
 	agentCtx := agentContext{
-		KubernetesVersion: fmt.Sprintf("%s.%s", version.Major, version.Minor),
+		KubernetesVersion: version.GitVersion,
 		Token:             *wcToken,
 	}
 


### PR DESCRIPTION
Major and minor is blank on the latest minikube build: https://github.com/kubernetes/minikube/issues/2505

Kuberenetes itself is also planning to deprecate these fields.

Use the git version (vX.X.X) instead, which the launch generator supports.