### PR TITLE
vendor: Update prometheus client_golang

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -367,10 +367,10 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
-  revision = "c5b7fccd204277076155f10851dad72b76a49317"
-  version = "v0.8.0"
+  revision = "9bb6ab929dcbe1c8393cd9ef70387cb69811bd1c"
 
 [[projects]]
   branch = "master"
@@ -769,6 +769,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "31adff00b3a94194a73b4d9f0f3baf18c8e22addf291507c64feded4113ed142"
+  inputs-digest = "546efbffebe90295f64c651c458a1f66c8106c688334f30e7405c416bc1f3936"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -82,3 +82,9 @@ branch = "release-1.9"
 [[override]]
   name = "github.com/docker/distribution"
   branch = "master"
+
+# Pin to master branch until there is a more recent stable release:
+#   https://github.com/prometheus/client_golang/issues/375
+[[constraint]]
+  name = "github.com/prometheus/client_golang"
+  branch = "master"


### PR DESCRIPTION
By default, go dep will take the latest stable version released. For
client_golang this means it will lock the 0.8.0 version from 2016-08-17. It
seems a sub-optimal default and was causing our golang services to be missing
interesting metrics and bug fixes.

Also filed: https://github.com/prometheus/client_golang/issues/375