### PR TITLE
test: Install nginx-bootstrap in a different NodePort

### DIFF
--- a/integration-tests/config.sh
+++ b/integration-tests/config.sh
@@ -7,7 +7,7 @@ DEFAULT_NGINX_BOOTSTRAP_IMAGE="quay.io/weaveworks/launcher-nginx-bootstrap:${IMA
 DEFAULT_BOOTSTRAP_BASE_URL="https://weaveworks-launcher.s3.amazonaws.com"
 
 # When run locally, we source bootstrap from a local nginx service
-[ -z "$CI" ] && BOOTSTRAP_BASE_URL="http://$(minikube ip):30081"
+[ -z "$CI" ] && BOOTSTRAP_BASE_URL="http://$(minikube ip):30091"
 
 cat <<EOF
 {

--- a/integration-tests/k8s/nginx-bootstrap.yaml.in
+++ b/integration-tests/k8s/nginx-bootstrap.yaml.in
@@ -6,7 +6,7 @@ spec:
   type: NodePort
   ports:
     - port: 80
-      nodePort: 30081
+      nodePort: 30091
   selector:
     name: nginx-bootstrap
 ---


### PR DESCRIPTION
authfe uses 30081 already, move it elsewhere so we can run both.