### PR TITLE
Refactor kubectl pkg to use a client interface

### DIFF
--- a/agent/flux.go
+++ b/agent/flux.go
@@ -15,8 +15,8 @@ type FluxConfig struct {
 	GitBranch string `long:"git-branch"`
 }
 
-func getFluxConfig(namespace string) (*FluxConfig, error) {
-	out, err := kubectl.Execute("get", "pod", "-n", namespace, "-l", "name=weave-flux-agent", "-o", "jsonpath='{.items[?(@.metadata.labels.name==\"weave-flux-agent\")].spec.containers[0].args[*]}'")
+func getFluxConfig(k kubectl.Client, namespace string) (*FluxConfig, error) {
+	out, err := k.Execute("get", "pod", "-n", namespace, "-l", "name=weave-flux-agent", "-o", "jsonpath='{.items[?(@.metadata.labels.name==\"weave-flux-agent\")].spec.containers[0].args[*]}'")
 	if err != nil {
 		return nil, err
 	}

--- a/agent/main.go
+++ b/agent/main.go
@@ -81,7 +81,7 @@ func updateAgents(cfg *agentConfig, cancel <-chan interface{}) {
 		return
 	}
 	log.Info("Revision before self-update: ", initialRevision)
-	err = kubectl.Apply(cfg.KubectlClient, cfg.AgentPollURL, []string{})
+	err = kubectl.Apply(cfg.KubectlClient, cfg.AgentPollURL)
 	if err != nil {
 		logError("Failed to execute kubectl apply", err, cfg)
 		return
@@ -133,7 +133,7 @@ func updateAgents(cfg *agentConfig, cancel <-chan interface{}) {
 		log.Fatal("invalid URL template:", err)
 	}
 	log.Info("Updating WC from ", wcPollURL)
-	err = kubectl.Apply(cfg.KubectlClient, wcPollURL, []string{})
+	err = kubectl.Apply(cfg.KubectlClient, wcPollURL)
 	if err != nil {
 		logError("Failed to execute kubectl apply", err, cfg)
 		return

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -51,7 +51,9 @@ func mainImpl() {
 		"weave_cloud_hostname": opts.Hostname,
 	})
 
-	if !kubectl.IsPresent() {
+	kubectlClient := kubectl.LocalClient{}
+
+	if !kubectlClient.IsPresent() {
 		die("Could not find kubectl in PATH, please install it: https://kubernetes.io/docs/tasks/tools/install-kubectl/\n")
 	}
 
@@ -66,7 +68,7 @@ func mainImpl() {
 	}
 
 	// Ask the user to confirm the cluster
-	cluster, err := kubectl.GetClusterInfo(otherArgs)
+	cluster, err := kubectl.GetClusterInfo(kubectlClient, otherArgs)
 	if err != nil {
 		die("There was an error fetching the current cluster info: %s\n", err)
 	}
@@ -74,24 +76,27 @@ func mainImpl() {
 	fmt.Printf("Installing Weave Cloud agents on %s at %s\n", cluster.Name, cluster.ServerAddress)
 
 	if opts.GKE {
-		err := createGKEClusterRoleBinding(otherArgs)
+		err := createGKEClusterRoleBinding(kubectlClient, otherArgs)
 		if err != nil {
 			fmt.Println("WARNING: For GKE installations, a cluster-admin clusterrolebinding is required.")
 			fmt.Printf("Could not create clusterrolebinding: %s", err)
 		}
 	}
 
-	secretCreated, err := createWCSecret(opts, otherArgs)
+	secretCreated, err := kubectl.CreateSecretFromLiteral(kubectlClient, "weave", "weave-cloud", "token", opts.Token, opts.AssumeYes, otherArgs)
 	if err != nil {
 		die("There was an error creating the secret: %s\n", err)
 	}
 	if !secretCreated {
-		fmt.Println("Cancelled.")
-		return
+		askForConfirmation("A weave-cloud secret already exists. Would you like to continue and replace the secret?")
+		_, err := kubectl.CreateSecretFromLiteral(kubectlClient, "weave", "weave-cloud", "token", opts.Token, true, otherArgs)
+		if err != nil {
+			die("There was an error creating the secret: %s\n", err)
+		}
 	}
 
 	// Apply the agent
-	_, err = kubectl.ExecuteWithGlobalArgs(otherArgs, "apply", "-f", agentK8sURL)
+	err = kubectl.Apply(kubectlClient, agentK8sURL, otherArgs)
 	if err != nil {
 		die("There was an error applying the agent: %s\n", err)
 	}
@@ -106,7 +111,7 @@ func die(msg string, args ...interface{}) {
 	os.Exit(1)
 }
 
-func createGKEClusterRoleBinding(otherArgs []string) error {
+func createGKEClusterRoleBinding(kubectlClient kubectl.Client, otherArgs []string) error {
 	if !gcloud.IsPresent() {
 		return errors.New("Could not find gcloud in PATH, please install it: https://cloud.google.com/sdk/docs/")
 	}
@@ -117,14 +122,12 @@ func createGKEClusterRoleBinding(otherArgs []string) error {
 	}
 	hostUser := os.Getenv("USER")
 
-	_, err = kubectl.ExecuteWithGlobalArgs(
-		otherArgs,
-		"create",
-		"clusterrolebinding",
+	err = kubectl.CreateClusterRoleBinding(
+		kubectlClient,
 		fmt.Sprintf("cluster-admin-%s", hostUser),
-		"--clusterrole=cluster-admin",
-		"--user",
+		"cluster-admin",
 		account,
+		otherArgs,
 	)
 	if err != nil {
 		return err
@@ -132,46 +135,7 @@ func createGKEClusterRoleBinding(otherArgs []string) error {
 	return nil
 }
 
-func createWCSecret(opts options, otherArgs []string) (bool, error) {
-	secretExists, err := kubectl.ResourceExists("secret", "weave-cloud", "weave", otherArgs)
-	if err != nil {
-		return false, err
-	}
-
-	if secretExists {
-		confirmed, err := askForConfirmation("A weave-cloud secret already exists. Would you like to continue and replace the secret?", opts.AssumeYes)
-		if err != nil {
-			return false, err
-		}
-		if !confirmed {
-			return false, nil
-		}
-
-		// Delete the secret
-		_, err = kubectl.ExecuteWithGlobalArgs(otherArgs, "delete", "secret", "weave-cloud", "--namespace=weave")
-		if err != nil {
-			return false, err
-		}
-	}
-
-	// Create the weave namespace and the weave-cloud secret
-	_, err = kubectl.CreateNamespace("weave", otherArgs)
-	if err != nil {
-		return false, err
-	}
-
-	_, err = kubectl.CreateSecretFromLiteral("weave", "weave-cloud", "token", opts.Token, otherArgs)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func askForConfirmation(s string, assumeYes bool) (bool, error) {
-	if assumeYes {
-		return true, nil
-	}
-
+func askForConfirmation(s string) (bool, error) {
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		fmt.Printf("%s [y/n]: ", s)

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -2,34 +2,14 @@ package kubectl
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 )
 
-func executeCommand(args []string) (string, error) {
-	cmdOut, err := exec.Command("kubectl", args...).CombinedOutput()
-	if err != nil {
-		// Kubectl error messages output to stdOut
-		return "", fmt.Errorf(formatCmdOutput(cmdOut))
-	}
-	return formatCmdOutput(cmdOut), nil
-}
-
-// Execute executes kubectl <args> and returns the combined stdout/err output.
-func Execute(args ...string) (string, error) {
-	return executeCommand(args)
-}
-
-// ExecuteWithGlobalArgs is a convenience version of Execute that lets the user
-// specify global arguments as an array. Global arguments are arguments that are
-// not specific to a kubectl sub-command, eg. --kubeconfig. The list of global
-// options can be retrieved with kubectl options.
-func ExecuteWithGlobalArgs(globalArgs []string, args ...string) (string, error) {
-	return executeCommand(append(globalArgs, args...))
-}
-
-func formatCmdOutput(output []byte) string {
-	return strings.TrimPrefix(strings.TrimSuffix(strings.TrimSpace(string(output)), "'"), "'")
+// Client implements a kubectl client to execute commands
+type Client interface {
+	Execute(args ...string) (string, error)
+	ExecuteWithGlobalArgs(globalArgs []string, args ...string) (string, error)
+	IsPresent() bool
 }
 
 // ClusterInfo describes a Kubernetes cluster
@@ -38,27 +18,21 @@ type ClusterInfo struct {
 	ServerAddress string
 }
 
-// IsPresent returns true if there's a kubectl command in the PATH.
-func IsPresent() bool {
-	_, err := exec.LookPath("kubectl")
-	return err == nil
-}
-
 // GetClusterInfo gets the current Kubernetes cluster information
-func GetClusterInfo(otherArgs []string) (ClusterInfo, error) {
-	currentContext, err := ExecuteWithGlobalArgs(otherArgs, "config", "current-context")
+func GetClusterInfo(c Client, otherArgs []string) (ClusterInfo, error) {
+	currentContext, err := c.ExecuteWithGlobalArgs(otherArgs, "config", "current-context")
 	if err != nil {
 		return ClusterInfo{}, err
 	}
 
-	name, err := ExecuteWithGlobalArgs(otherArgs, "config", "view",
+	name, err := c.ExecuteWithGlobalArgs(otherArgs, "config", "view",
 		fmt.Sprintf("-o=jsonpath='{.contexts[?(@.name == \"%s\")].context.cluster}'", currentContext),
 	)
 	if err != nil {
 		return ClusterInfo{}, err
 	}
 
-	serverAddress, err := ExecuteWithGlobalArgs(otherArgs,
+	serverAddress, err := c.ExecuteWithGlobalArgs(otherArgs,
 		"config",
 		"view",
 		fmt.Sprintf("-o=jsonpath='{.clusters[?(@.name == \"%s\")].cluster.server}'", name),
@@ -73,33 +47,15 @@ func GetClusterInfo(otherArgs []string) (ClusterInfo, error) {
 	}, nil
 }
 
-// CreateNamespace creates a new namespace and returns whether it was created or not
-func CreateNamespace(namespace string, otherArgs []string) (bool, error) {
-	_, err := ExecuteWithGlobalArgs(otherArgs, "create", "namespace", namespace)
-	if err != nil {
-		if strings.Contains(err.Error(), "AlreadyExists") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
-// CreateSecretFromLiteral creates a new secret with a single (key,value) pair.
-func CreateSecretFromLiteral(namespace, secretName, key, value string, otherArgs []string) (string, error) {
-	return ExecuteWithGlobalArgs(otherArgs,
-		fmt.Sprintf("--namespace=%s", namespace),
-		"create",
-		"secret",
-		"generic",
-		secretName,
-		fmt.Sprintf("--from-literal=%s=%s", key, value),
-	)
+// Apply applies via kubectl
+func Apply(c Client, f string, otherArgs []string) error {
+	_, err := c.ExecuteWithGlobalArgs(otherArgs, "apply", "-f", f)
+	return err
 }
 
 // ResourceExists return true if the resource exists
-func ResourceExists(resourceType, resourceName, namespace string, otherArgs []string) (bool, error) {
-	_, err := ExecuteWithGlobalArgs(otherArgs, "get", resourceType, resourceName, fmt.Sprintf("--namespace=%s", namespace))
+func ResourceExists(c Client, resourceType, namespace, resourceName string, otherArgs []string) (bool, error) {
+	_, err := c.ExecuteWithGlobalArgs(otherArgs, "get", resourceType, resourceName, fmt.Sprintf("--namespace=%s", namespace))
 	if err != nil {
 		// k8s 1.4 answers with "Error from server: secrets "weave-cloud" not found"
 		// More recent versions with "Error from server (NotFound): secrets "weave-cloud" not found
@@ -110,5 +66,77 @@ func ResourceExists(resourceType, resourceName, namespace string, otherArgs []st
 		}
 		return false, err
 	}
+	return true, nil
+}
+
+// DeleteResource deletes a resource
+func DeleteResource(c Client, resourceType, namespace, resourceName string, otherArgs []string) error {
+	_, err := c.ExecuteWithGlobalArgs(otherArgs, "delete", resourceType, resourceName, fmt.Sprintf("--namespace=%s", namespace))
+	return err
+}
+
+// CreateNamespace creates a new namespace and returns whether it was created or not
+func CreateNamespace(c Client, namespace string, otherArgs []string) (bool, error) {
+	_, err := c.ExecuteWithGlobalArgs(otherArgs, "create", "namespace", namespace)
+	if err != nil {
+		if strings.Contains(err.Error(), "AlreadyExists") {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// CreateClusterRoleBinding creates a new cluster role binding
+func CreateClusterRoleBinding(c Client, name, role, user string, otherArgs []string) error {
+	_, err := c.ExecuteWithGlobalArgs(
+		otherArgs,
+		"create",
+		"clusterrolebinding",
+		name,
+		"--clusterrole",
+		role,
+		"--user",
+		user,
+	)
+	return err
+}
+
+// CreateSecretFromLiteral creates a new secret with a single (key,value) pair.
+func CreateSecretFromLiteral(c Client, namespace, name, key, value string, override bool, otherArgs []string) (bool, error) {
+	secretExists, err := ResourceExists(c, "secret", namespace, name, otherArgs)
+	if err != nil {
+		return false, err
+	}
+
+	if secretExists {
+		if !override {
+			return false, nil
+		}
+		err := DeleteResource(c, "secret", namespace, name, otherArgs)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	// Create the weave namespace and the weave-cloud secret
+	_, err = CreateNamespace(c, namespace, otherArgs)
+	if err != nil {
+		return false, err
+	}
+
+	// Create the secret
+	_, err = c.ExecuteWithGlobalArgs(otherArgs,
+		fmt.Sprintf("--namespace=%s", namespace),
+		"create",
+		"secret",
+		"generic",
+		name,
+		fmt.Sprintf("--from-literal=%s=%s", key, value),
+	)
+	if err != nil {
+		return false, err
+	}
+
 	return true, nil
 }

--- a/pkg/kubectl/local.go
+++ b/pkg/kubectl/local.go
@@ -7,7 +7,9 @@ import (
 )
 
 // LocalClient implements Kubectl
-type LocalClient struct{}
+type LocalClient struct {
+	GlobalArgs []string
+}
 
 // IsPresent returns true if there's a kubectl command in the PATH.
 func (k LocalClient) IsPresent() bool {
@@ -17,19 +19,7 @@ func (k LocalClient) IsPresent() bool {
 
 // Execute executes kubectl <args> and returns the combined stdout/err output.
 func (k LocalClient) Execute(args ...string) (string, error) {
-	return executeCommand(args)
-}
-
-// ExecuteWithGlobalArgs is a convenience version of Execute that lets the user
-// specify global arguments as an array. Global arguments are arguments that are
-// not specific to a kubectl sub-command, eg. --kubeconfig. The list of global
-// options can be retrieved with kubectl options.
-func (k LocalClient) ExecuteWithGlobalArgs(globalArgs []string, args ...string) (string, error) {
-	return executeCommand(append(globalArgs, args...))
-}
-
-func executeCommand(args []string) (string, error) {
-	cmdOut, err := exec.Command("kubectl", args...).CombinedOutput()
+	cmdOut, err := exec.Command("kubectl", append(k.GlobalArgs, args...)...).CombinedOutput()
 	if err != nil {
 		// Kubectl error messages output to stdOut
 		return "", fmt.Errorf(formatCmdOutput(cmdOut))

--- a/pkg/kubectl/local.go
+++ b/pkg/kubectl/local.go
@@ -1,0 +1,42 @@
+package kubectl
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// LocalClient implements Kubectl
+type LocalClient struct{}
+
+// IsPresent returns true if there's a kubectl command in the PATH.
+func (k LocalClient) IsPresent() bool {
+	_, err := exec.LookPath("kubectl")
+	return err == nil
+}
+
+// Execute executes kubectl <args> and returns the combined stdout/err output.
+func (k LocalClient) Execute(args ...string) (string, error) {
+	return executeCommand(args)
+}
+
+// ExecuteWithGlobalArgs is a convenience version of Execute that lets the user
+// specify global arguments as an array. Global arguments are arguments that are
+// not specific to a kubectl sub-command, eg. --kubeconfig. The list of global
+// options can be retrieved with kubectl options.
+func (k LocalClient) ExecuteWithGlobalArgs(globalArgs []string, args ...string) (string, error) {
+	return executeCommand(append(globalArgs, args...))
+}
+
+func executeCommand(args []string) (string, error) {
+	cmdOut, err := exec.Command("kubectl", args...).CombinedOutput()
+	if err != nil {
+		// Kubectl error messages output to stdOut
+		return "", fmt.Errorf(formatCmdOutput(cmdOut))
+	}
+	return formatCmdOutput(cmdOut), nil
+}
+
+func formatCmdOutput(output []byte) string {
+	return strings.TrimPrefix(strings.TrimSuffix(strings.TrimSpace(string(output)), "'"), "'")
+}

--- a/pkg/kubectl/local_test.go
+++ b/pkg/kubectl/local_test.go
@@ -21,6 +21,7 @@ func TestFormatCmdOutput(t *testing.T) {
 	}
 }
 
-func ExampleExecute() {
-	Execute("apply", "-f", "service.yaml")
+func ExampleLocalClient() {
+	local := LocalClient{}
+	local.Execute("apply", "-f", "service.yaml")
 }


### PR DESCRIPTION
- Use a kubectl client interface to allow us to reuse the logic when installing WC via other packages (e.g. remotely on GKE clusters).
- Make GlobalArgs a Client implementation detail to simplify interface and prevent misue of `Execute` vs `ExecuteWithGlobalArgs`