### PR TITLE
bootstrap: Add the GKE clusterrolebinding error to the sentry context

### DIFF
--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -92,6 +92,9 @@ func mainImpl() {
 	if opts.GKE {
 		err := createGKEClusterRoleBinding(kubectlClient)
 		if err != nil {
+			raven.SetTagsContext(map[string]string{
+				"gke_clusterrolebindingError": err.Error(),
+			})
 			fmt.Fprintln(os.Stderr, "WARNING: For GKE installations, a cluster-admin clusterrolebinding is required.")
 			fmt.Fprintf(os.Stderr, "Could not create clusterrolebinding: %s\n", err)
 		}


### PR DESCRIPTION
When the final kubectl apply fails on GKE, we'd love to know why we weren't
able to create the cluster-admin role.

Based on that data, we can decide for a course of action to solve #117

Updates: #117