### PR TITLE
Better error reporting

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/weaveworks/launcher/pkg/k8s"
 	"github.com/weaveworks/launcher/pkg/kubectl"
+	"github.com/weaveworks/launcher/pkg/sentry"
 	"github.com/weaveworks/launcher/pkg/text"
 	"github.com/weaveworks/launcher/pkg/weavecloud"
 )
@@ -66,18 +67,12 @@ func logError(msg string, err error, cfg *agentConfig) {
 	formatted := fmt.Sprintf("%s: %s", msg, err)
 	log.Error(formatted)
 
-	ravenTags := map[string]string{
+	tags := map[string]string{
 		"kubernetes": cfg.KubernetesVersion,
 		"instance":   cfg.InstanceID,
 	}
 
-	// Capture the error with stacktrace and wait.
-	stack := raven.NewStacktrace(1, 3, nil)
-	packet := raven.NewPacket(formatted, stack)
-	eventID, ch := raven.Capture(packet, ravenTags)
-	if eventID != "" {
-		<-ch
-	}
+	sentry.Capture(formatted, 2, tags)
 }
 
 func updateAgents(cfg *agentConfig, cancel <-chan interface{}) {

--- a/agent/main.go
+++ b/agent/main.go
@@ -67,7 +67,7 @@ func logError(msg string, err error, cfg *agentConfig) {
 	formatted := fmt.Sprintf("%s: %s", msg, err)
 	log.Error(formatted)
 
-	sentry.Capture(formatted, 2, nil)
+	sentry.CaptureAndWait(1, formatted, nil)
 }
 
 func updateAgents(cfg *agentConfig, cancel <-chan interface{}) {

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -116,7 +116,7 @@ func mainImpl() {
 	// Apply the agent
 	err = kubectl.Apply(kubectlClient, agentK8sURL)
 	if err != nil {
-		capture(2, "There was an error applying the agent: %s\n", err)
+		capture(1, "There was an error applying the agent: %s\n", err)
 
 		// We've failed to apply the agent. kubectl apply isn't an atomic operation
 		// can leave some objects behind when encountering an error. Clean things up.
@@ -133,14 +133,14 @@ func exitNoCapture(msg string, args ...interface{}) {
 	os.Exit(1)
 }
 
-func capture(skipFrames int, msg string, args ...interface{}) {
+func capture(skipFrames uint, msg string, args ...interface{}) {
 	formatted := fmt.Sprintf(msg, args...)
 	fmt.Fprintf(os.Stderr, formatted)
-	sentry.Capture(formatted, skipFrames, nil)
+	sentry.CaptureAndWait(skipFrames, formatted, nil)
 }
 
 func exitWithCapture(msg string, args ...interface{}) {
-	capture(3, msg, args...)
+	capture(2, msg, args...)
 	os.Exit(1)
 }
 

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jessevdk/go-flags"
 	"github.com/weaveworks/launcher/pkg/gcloud"
 	"github.com/weaveworks/launcher/pkg/kubectl"
+	"github.com/weaveworks/launcher/pkg/sentry"
 	"github.com/weaveworks/launcher/pkg/text"
 )
 
@@ -115,7 +116,7 @@ func mainImpl() {
 	// Apply the agent
 	err = kubectl.Apply(kubectlClient, agentK8sURL)
 	if err != nil {
-		capture("There was an error applying the agent: %s\n", err)
+		capture(2, "There was an error applying the agent: %s\n", err)
 
 		// We've failed to apply the agent. kubectl apply isn't an atomic operation
 		// can leave some objects behind when encountering an error. Clean things up.
@@ -132,14 +133,14 @@ func exitNoCapture(msg string, args ...interface{}) {
 	os.Exit(1)
 }
 
-func capture(msg string, args ...interface{}) {
+func capture(skipFrames int, msg string, args ...interface{}) {
 	formatted := fmt.Sprintf(msg, args...)
 	fmt.Fprintf(os.Stderr, formatted)
-	raven.CaptureMessageAndWait(formatted, nil)
+	sentry.Capture(formatted, skipFrames, nil)
 }
 
 func exitWithCapture(msg string, args ...interface{}) {
-	capture(msg, args...)
+	capture(3, msg, args...)
 	os.Exit(1)
 }
 

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -4,24 +4,25 @@ import (
 	raven "github.com/getsentry/raven-go"
 )
 
-// Capture reports an error message to sentry along with a stacktrace.
+// CaptureAndWait reports an error message to sentry along with a stacktrace.
 //
 // skipFrames can be used to indicate how many stack frames should be skipped to
-// reach the frame where the error actually happened instead of always pointing
-// to a generic "logError()".
+// reach the frame where the error actually happened, eg.:
+// - When Capture is called directly from the location that should appear in the
+// stack trace, skipFrames should be 0.
+// - When Capture is called from a helper function, eg. to both log to stdout
+// and sentry, that helper function frame can be skipped by giving 1.
 //
-// tags are additional tags to add the sentry event.
+// tags are additional tags to add to the sentry event.
 //
 // This call is synchronous in that it will not return until the message has
 // been sent to sentry.
-func Capture(message string, skipFrames int, tags map[string]string) {
-	// We want to at least skip the Capture() function itself.
-	if skipFrames < 1 {
-		skipFrames = 1
-	}
+func CaptureAndWait(skipFrames uint, message string, tags map[string]string) {
+	// We want to skip the Capture() function itself.
+	skipFrames++
 
 	// Capture the error with stacktrace and wait.
-	stack := raven.NewStacktrace(skipFrames, 3, nil)
+	stack := raven.NewStacktrace(int(skipFrames), 3, nil)
 	packet := raven.NewPacket(message, stack)
 	eventID, ch := raven.Capture(packet, tags)
 	if eventID != "" {

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -1,0 +1,30 @@
+package sentry
+
+import (
+	raven "github.com/getsentry/raven-go"
+)
+
+// Capture reports an error message to sentry along with a stacktrace.
+//
+// skipFrames can be used to indicate how many stack frames should be skipped to
+// reach the frame where the error actually happened instead of always pointing
+// to a generic "logError()".
+//
+// tags are additional tags to add the sentry event.
+//
+// This call is synchronous in that it will not return until the message has
+// been sent to sentry.
+func Capture(message string, skipFrames int, tags map[string]string) {
+	// We want to at least skip the Capture() function itself.
+	if skipFrames < 1 {
+		skipFrames = 1
+	}
+
+	// Capture the error with stacktrace and wait.
+	stack := raven.NewStacktrace(skipFrames, 3, nil)
+	packet := raven.NewPacket(message, stack)
+	eventID, ch := raven.Capture(packet, tags)
+	if eventID != "" {
+		<-ch
+	}
+}

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -8,10 +8,10 @@ import (
 //
 // skipFrames can be used to indicate how many stack frames should be skipped to
 // reach the frame where the error actually happened, eg.:
-// - When Capture is called directly from the location that should appear in the
-// stack trace, skipFrames should be 0.
-// - When Capture is called from a helper function, eg. to both log to stdout
-// and sentry, that helper function frame can be skipped by giving 1.
+// - When CaptureAndWait is called directly from the location that should appear
+// in the stack trace, skipFrames should be 0.
+// - When CaptureAndWait is called from a helper function, eg. to both log to
+// stdout and sentry, that helper function frame can be skipped by giving 1.
 //
 // tags are additional tags to add to the sentry event.
 //


### PR DESCRIPTION
We noticed a few bad things:

- Agent events were all classified under one error because events with the same stack frame are aggregated together.
- Bootstrap events didn't have any stack frame associated with them.
- raven's Exception object prefixes error messages with the type of the `error`. The issue is that most errors we used are directly from `errors.New()` or indirectly from `fmt.Errorf()`. They have the same type: `*errors.errorString`. Sentry picked that up as the error name, which lead to having a walll of "errors.errorString" errors instead of more interesting messages.
- We weren't reporting some of the errors in agent when trying to talk to Kubernetes.