### PR TITLE
Avoid prompting when overwriting secrets unless the instance ID differs 

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -32,7 +32,6 @@ const (
 		"&git-label={{.FluxConfig.GitLabel}}&git-url={{.FluxConfig.GitURL}}" +
 		"&git-path={{.FluxConfig.GitPath}}&git-branch={{.FluxConfig.GitBranch}}" +
 		"{{end}}"
-	defaultWCOrgLookupURL = "https://{{.WCHostname}}/api/users/org/lookup"
 )
 
 type agentConfig struct {
@@ -168,7 +167,7 @@ func mainImpl() {
 	wcToken := flag.String("wc.token", "", "Weave Cloud instance token")
 	wcPollInterval := flag.Duration("wc.poll-interval", 1*time.Hour, "Polling interval to check WC manifests")
 	wcPollURLTemplate := flag.String("wc.poll-url", defaultWCPollURL, "URL to poll for WC manifests")
-	wcOrgLookupURLTemplate := flag.String("wc.org-lookup-url", defaultWCOrgLookupURL, "URL to lookup org external ID by token")
+	wcOrgLookupURLTemplate := flag.String("wc.org-lookup-url", weavecloud.DefaultWCOrgLookupURLTemplate, "URL to lookup org external ID by token")
 	wcHostname := flag.String("wc.hostname", defaultWCHostname, "WC Hostname for WC agents and users API")
 
 	eventsReportInterval := flag.Duration("events.report-interval", 3*time.Second, "Minimal time interval between two reports")

--- a/agent/main.go
+++ b/agent/main.go
@@ -211,7 +211,7 @@ func mainImpl() {
 	if err != nil {
 		log.Fatal("invalid URL template:", err)
 	}
-	instanceID, err := weavecloud.LookupInstanceByToken(wcOrgLookupURL, *wcToken)
+	instanceID, _, err := weavecloud.LookupInstanceByToken(wcOrgLookupURL, *wcToken)
 	if err != nil {
 		logError("lookup instance by token", err, &agentConfig{})
 	}

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -19,16 +19,16 @@ import (
 )
 
 const (
-	agentK8sURLTemplate = "{{.Scheme}}://{{.Hostname}}/k8s/agent.yaml"
+	agentK8sURLTemplate = "{{.Scheme}}://{{.LauncherHostname}}/k8s/agent.yaml"
 )
 
 type options struct {
-	AssumeYes  bool   `short:"y" long:"assume-yes" description:"Install without user confirmation"`
-	Scheme     string `long:"scheme" description:"Weave Cloud scheme" default:"https"`
-	Hostname   string `long:"hostname" description:"Weave Cloud launcher hostname" default:"get.weave.works"`
-	WCHostname string `long:"wc-hostname" description:"Weave Cloud hostname" default:"cloud.weave.works"`
-	Token      string `long:"token" description:"Weave Cloud token" required:"true"`
-	GKE        bool   `long:"gke" description:"Create clusterrolebinding for GKE instances"`
+	AssumeYes        bool   `short:"y" long:"assume-yes" description:"Install without user confirmation"`
+	Scheme           string `long:"scheme" description:"Weave Cloud scheme" default:"https"`
+	LauncherHostname string `long:"wc.launcher" description:"Weave Cloud launcher hostname" default:"get.weave.works"`
+	WCHostname       string `long:"wc.hostname" description:"Weave Cloud hostname" default:"cloud.weave.works"`
+	Token            string `long:"token" description:"Weave Cloud token" required:"true"`
+	GKE              bool   `long:"gke" description:"Create clusterrolebinding for GKE instances"`
 }
 
 func init() {
@@ -50,7 +50,8 @@ func mainImpl() {
 	}
 	raven.SetTagsContext(map[string]string{
 		"weave_cloud_scheme":   opts.Scheme,
-		"weave_cloud_hostname": opts.Hostname,
+		"weave_cloud_launcher": opts.LauncherHostname,
+		"weave_cloud_hostname": opts.WCHostname,
 	})
 
 	kubectlClient := kubectl.LocalClient{

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -89,7 +89,7 @@ func mainImpl() {
 
 	InstanceID, InstanceName, err := weavecloud.LookupInstanceByToken(wcOrgLookupURL, opts.Token)
 	if err != nil {
-		exitWithCapture("Error looking up Weave Cloud instance\n", err)
+		exitWithCapture("Error looking up Weave Cloud instance: %s\n", err)
 	}
 	raven.SetTagsContext(map[string]string{"instance": InstanceID})
 	fmt.Printf("Connecting cluster to %q (id: %s) on Weave Cloud\n", InstanceName, InstanceID)

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -75,6 +75,8 @@ func mainImpl() {
 		exitWithCapture("Could not restore stdin\n", err)
 	}
 
+	fmt.Println("Preparing for Weave Cloud setup")
+
 	// Capture the kubernetes version info to help debug issues
 	fmt.Println("Checking kubectl & kubernetes versions")
 	versionMeta, err := kubectl.GetVersionInfo(kubectlClient)

--- a/integration-tests/config.sh
+++ b/integration-tests/config.sh
@@ -13,7 +13,7 @@ cat <<EOF
 {
   "Service": {
     "Scheme": "http",
-    "Hostname": "$(minikube ip):30080",
+    "LauncherHostname": "$(minikube ip):30080",
     "WCHostname": "frontend.dev.weave.works",
     "Image": "${SERVICE_IMAGE-$DEFAULT_SERVICE_IMAGE}"
   },

--- a/integration-tests/k8s/service.updated.yaml.in
+++ b/integration-tests/k8s/service.updated.yaml.in
@@ -27,7 +27,7 @@ spec:
         image: {{.Service.Image}}
         args:
         - -scheme={{.Service.Scheme}}
-        - -hostname={{.Service.Hostname}}
+        - -hostname={{.Service.LauncherHostname}}
         - -wcHostname={{.Service.WCHostname}}
         - -bootstrap.base-url={{.Bootstrap.BaseURL}}
         - -agent-manifest=/agent-k8s/agent.updated.yaml

--- a/integration-tests/k8s/service.yaml.in
+++ b/integration-tests/k8s/service.yaml.in
@@ -27,7 +27,7 @@ spec:
         image: {{.Service.Image}}
         args:
         - -scheme={{.Service.Scheme}}
-        - -hostname={{.Service.Hostname}}
+        - -hostname={{.Service.LauncherHostname}}
         - -wcHostname={{.Service.WCHostname}}
         - -bootstrap.base-url={{.Bootstrap.BaseURL}}
         ports:

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -191,7 +191,7 @@ func GetSecretValue(c Client, namespace, name, key string) (string, error) {
 	}
 	encoded, ok := secretDefn.Data[key]
 	if !ok {
-		return "", fmt.Errorf("Secret missing key %s", key)
+		return "", fmt.Errorf("Secret missing key %q", key)
 	}
 	valueBytes, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {

--- a/pkg/kubectl/kubectl_test.go
+++ b/pkg/kubectl/kubectl_test.go
@@ -1,0 +1,42 @@
+package kubectl
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestClient struct {
+	responses map[string]string
+}
+
+func NewTestClient() *TestClient {
+	tc := &TestClient{}
+	tc.responses = map[string]string{}
+	return tc
+}
+
+func (t *TestClient) Execute(args ...string) (string, error) {
+	cmd := strings.Join(args, " ")
+	response, ok := t.responses[cmd]
+	if ok {
+		return response, nil
+	}
+	return "", fmt.Errorf("Missing response for %q", cmd)
+}
+
+func (t *TestClient) ExecuteStdout(args ...string) (string, error) {
+	return Execute(t, args...)
+}
+
+func TestGetSecretValue(t *testing.T) {
+	tc := NewTestClient()
+
+	json := `{"data":{"token": "c2VjcmV0IQ=="}}`
+	tc.responses["get secret weave-cloud --namespace=weave -ojson"] = json
+	res, err := GetSecretValue(tc, "weave", "weave-cloud", "token")
+	assert.Equal(t, res, "secret!")
+	assert.NoError(t, err)
+}

--- a/pkg/weavecloud/instances.go
+++ b/pkg/weavecloud/instances.go
@@ -7,6 +7,7 @@ import (
 )
 
 type lookupInstanceByTokenView struct {
+	Name       string `json:"name"`
 	ExternalID string `json:"externalID"`
 }
 
@@ -14,17 +15,17 @@ type lookupInstanceByTokenView struct {
 const DefaultWCOrgLookupURLTemplate = "https://{{.WCHostname}}/api/users/org/lookup"
 
 // LookupInstanceByToken returns the instance ID given an instance token
-func LookupInstanceByToken(apiURL, token string) (string, error) {
+func LookupInstanceByToken(apiURL, token string) (string, string, error) {
 	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	instance := lookupInstanceByTokenView{}
@@ -32,8 +33,8 @@ func LookupInstanceByToken(apiURL, token string) (string, error) {
 	defer resp.Body.Close()
 	err = json.NewDecoder(resp.Body).Decode(&instance)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	return instance.ExternalID, nil
+	return instance.ExternalID, instance.Name, nil
 }

--- a/pkg/weavecloud/instances.go
+++ b/pkg/weavecloud/instances.go
@@ -27,10 +27,15 @@ func LookupInstanceByToken(apiURL, token string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", "", fmt.Errorf("Invalid token")
+	} else if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf(resp.Status)
+	}
 
 	instance := lookupInstanceByTokenView{}
-
-	defer resp.Body.Close()
 	err = json.NewDecoder(resp.Body).Decode(&instance)
 	if err != nil {
 		return "", "", err

--- a/pkg/weavecloud/instances.go
+++ b/pkg/weavecloud/instances.go
@@ -10,6 +10,9 @@ type lookupInstanceByTokenView struct {
 	ExternalID string `json:"externalID"`
 }
 
+// DefaultWCOrgLookupURLTemplate is the default URL template for LookupInstanceByToken
+const DefaultWCOrgLookupURLTemplate = "https://{{.WCHostname}}/api/users/org/lookup"
+
 // LookupInstanceByToken returns the instance ID given an instance token
 func LookupInstanceByToken(apiURL, token string) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, apiURL, nil)

--- a/pkg/weavecloud/instances_test.go
+++ b/pkg/weavecloud/instances_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	instanceName  = "Awesome Instance"
 	instanceID    = "awesome-instance"
 	instanceToken = "WEAVE_CLOUD_TOKEN_123"
 )
@@ -23,12 +24,14 @@ func TestLookupInstanceByToken(t *testing.T) {
 		json.NewEncoder(w).Encode(
 			lookupInstanceByTokenView{
 				ExternalID: instanceID,
+				Name:       instanceName,
 			},
 		)
 	}))
 	defer ts.Close()
 
-	id, err := LookupInstanceByToken(ts.URL, instanceToken)
+	id, name, err := LookupInstanceByToken(ts.URL, instanceToken)
 	assert.NoError(t, err)
 	assert.Equal(t, instanceID, id)
+	assert.Equal(t, instanceName, name)
 }

--- a/service/main.go
+++ b/service/main.go
@@ -20,14 +20,14 @@ const (
 )
 
 type templateData struct {
-	Scheme     string
-	Hostname   string
-	WCHostname string
+	Scheme           string
+	LauncherHostname string
+	WCHostname       string
 }
 
 var (
 	bootstrapVersion = flag.String("bootstrap-version", "", "Bootstrap version used for S3 binaries (commit hash)")
-	hostname         = flag.String("hostname", "get.weave.works", "Hostname for external launcher service")
+	launcherHostname = flag.String("hostname", "get.weave.works", "Hostname for external launcher service")
 	wcHostname       = flag.String("wcHostname", "cloud.weave.works", "Hostname for WC agents and users API")
 	scheme           = flag.String("scheme", "https", "URL scheme for external launcher service")
 	bootstrapBaseURL = flag.String("bootstrap.base-url", s3Bucket, "Base URL the bootstrap binary should be fetched from")
@@ -48,9 +48,9 @@ func main() {
 
 	// Load install.sh and agent.yaml into memory
 	data := &templateData{
-		Scheme:     *scheme,
-		Hostname:   *hostname,
-		WCHostname: *wcHostname,
+		Scheme:           *scheme,
+		LauncherHostname: *launcherHostname,
+		WCHostname:       *wcHostname,
 	}
 	installScriptData, err := loadData(installScriptFile, data)
 	if err != nil {

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -124,8 +124,8 @@ func TestAgentYAMLHandler(t *testing.T) {
 
 func TestLoadData(t *testing.T) {
 	ctx := &templateData{
-		Scheme:   "https",
-		Hostname: "hostname.test",
+		Scheme:           "https",
+		LauncherHostname: "hostname.test",
 	}
 	// install.sh
 	installScriptData, err := loadData("./static/install.sh", ctx)
@@ -137,8 +137,8 @@ func TestLoadData(t *testing.T) {
 	if !strings.Contains(installScript, "https://hostname.test/bootstrap?dist=$dist") {
 		t.Errorf("Expected 'https://hostname.test/bootstrap?dist=$dist' in install.sh")
 	}
-	if !strings.Contains(installScript, "--hostname=hostname.test") {
-		t.Errorf("Expected '--hostname=hostname.test' in install.sh")
+	if !strings.Contains(installScript, "--wc.launcher=hostname.test") {
+		t.Errorf("Expected '--wc.launcher=hostname.test' in install.sh")
 	}
 
 	// agent.yaml

--- a/service/static/agent.yaml.in
+++ b/service/static/agent.yaml.in
@@ -75,6 +75,6 @@ items:
                       name: weave-cloud
                       key: token
               args:
-              - -agent.poll-url={{.Scheme}}://{{.Hostname}}/k8s/agent.yaml?instanceID={{"{{.InstanceID}}"}}
+              - -agent.poll-url={{.Scheme}}://{{.LauncherHostname}}/k8s/agent.yaml?instanceID={{"{{.InstanceID}}"}}
               - -wc.hostname={{.WCHostname}}
               - -wc.token=$(WEAVE_CLOUD_TOKEN)

--- a/service/static/install.sh
+++ b/service/static/install.sh
@@ -37,10 +37,10 @@ fi
 
 # Download the bootstrap binary
 echo "Downloading the Weave Cloud installer...  "
-curl -Ls "{{.Scheme}}://{{.Hostname}}/bootstrap?dist=$dist" >> "$TMPFILE"
+curl -Ls "{{.Scheme}}://{{.LauncherHostname}}/bootstrap?dist=$dist" >> "$TMPFILE"
 
 # Make the bootstrap binary executable
 chmod +x "$TMPFILE"
 
 # Execute the bootstrap binary
-"$TMPFILE" "--scheme={{.Scheme}}" "--hostname={{.Hostname}}" "--wc-hostname={{.WCHostname}}" "$@"
+"$TMPFILE" "--scheme={{.Scheme}}" "--wc.launcher={{.LauncherHostname}}" "--wc.hostname={{.WCHostname}}" "$@"

--- a/service/static/install.sh
+++ b/service/static/install.sh
@@ -43,4 +43,4 @@ curl -Ls "{{.Scheme}}://{{.Hostname}}/bootstrap?dist=$dist" >> "$TMPFILE"
 chmod +x "$TMPFILE"
 
 # Execute the bootstrap binary
-"$TMPFILE" "--scheme={{.Scheme}}" "--hostname={{.Hostname}}" "$@"
+"$TMPFILE" "--scheme={{.Scheme}}" "--hostname={{.Hostname}}" "--wc-hostname={{.WCHostname}}" "$@"


### PR DESCRIPTION
Also print the instance name when installing, and also if we do have to prompt.
Fixes https://github.com/weaveworks/launcher/issues/59

If the secret is missing or already matches:
```
Preparing for Weave Cloud setup
Checking kubectl & kubernetes versions
Connecting cluster to "" (id: thawing-fog-13) on Weave Cloud
Installing Weave Cloud agents on minikube at https://192.168.99.100:8443
Successfully installed.
```

If there is a secret:
```
Preparing for Weave Cloud setup
Checking kubectl & kubernetes versions
Connecting cluster to "" (id: thawing-fog-13) on Weave Cloud
Installing Weave Cloud agents on minikube at https://192.168.99.100:8443

This cluster is currently connected to "" (id: still-flower-11) on Weave Cloud
Would you like to continue and connect this cluster to "" (id: thawing-fog-13) instead? [y/n]: y
Successfully installed.
```

Once https://github.com/weaveworks/service/pull/1813 hits dev, the `""` above should be the instance name instead.