### PR TITLE
Improve errors from running kubectl

### DIFF
--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -217,18 +217,18 @@ func askForConfirmation(s string) (bool, error) {
 func checkK8sVersion(kubectlClient kubectl.Client) {
 	fmt.Println("Checking kubectl & kubernetes versions")
 	clientVersion, serverVersion, err := kubectl.GetVersionInfo(kubectlClient)
-	if err == nil {
+	if clientVersion != "" {
 		raven.SetTagsContext(map[string]string{
 			"kubectl_clientVersion_gitVersion": clientVersion,
 		})
 		if serverVersion == "" {
-			exitNoCapture("Error loading the kubernetes server version, please check that you can connect to it by running \"kubectl version\".\n")
+			exitNoCapture("%v\nError loading the kubernetes server version.\nPlease check that you can connect to it by running \"kubectl version\".\n", err)
 		} else {
 			raven.SetTagsContext(map[string]string{
 				"kubectl_serverVersion_gitVersion": serverVersion,
 			})
 		}
 	} else {
-		exitNoCapture("Error loading kubernetes version info, please check your environment for problems by running \"kubectl version\".\n")
+		exitNoCapture("%v\nError loading kubernetes version info.\nPlease check your environment for problems by running \"kubectl version\".\n", err)
 	}
 }

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -47,7 +47,7 @@ func mainImpl() {
 	parser := flags.NewParser(&opts, flags.IgnoreUnknown)
 	otherArgs, err := parser.Parse()
 	if err != nil {
-		exitNoCapture("%s\n", err)
+		exitWithCapture("%s\n", err)
 	}
 	raven.SetTagsContext(map[string]string{
 		"weave_cloud_scheme":   opts.Scheme,
@@ -60,7 +60,7 @@ func mainImpl() {
 	}
 
 	if !kubectlClient.IsPresent() {
-		exitNoCapture("Could not find kubectl in PATH, please install it: https://kubernetes.io/docs/tasks/tools/install-kubectl/\n")
+		exitWithCapture("Could not find kubectl in PATH, please install it: https://kubernetes.io/docs/tasks/tools/install-kubectl/\n")
 	}
 
 	agentK8sURL, err := text.ResolveString(agentK8sURLTemplate, opts)
@@ -133,7 +133,7 @@ func mainImpl() {
 			if err != nil {
 				exitWithCapture("Could not ask for confirmation: %s\n", err)
 			} else if !confirmed {
-				exitNoCapture("Installation cancelled")
+				exitWithCapture("Installation cancelled")
 			}
 			_, err = kubectl.CreateSecretFromLiteral(kubectlClient, "weave", "weave-cloud", "token", opts.Token, true)
 			if err != nil {
@@ -155,11 +155,6 @@ func mainImpl() {
 	}
 
 	fmt.Println("Successfully installed.")
-}
-
-func exitNoCapture(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg, args...)
-	os.Exit(1)
 }
 
 func capture(skipFrames uint, msg string, args ...interface{}) {
@@ -222,13 +217,13 @@ func checkK8sVersion(kubectlClient kubectl.Client) {
 			"kubectl_clientVersion_gitVersion": clientVersion,
 		})
 		if serverVersion == "" {
-			exitNoCapture("%v\nError loading the kubernetes server version.\nPlease check that you can connect to it by running \"kubectl version\".\n", err)
+			exitWithCapture("%v\nError loading the kubernetes server version.\nPlease check that you can connect to it by running \"kubectl version\".\n", err)
 		} else {
 			raven.SetTagsContext(map[string]string{
 				"kubectl_serverVersion_gitVersion": serverVersion,
 			})
 		}
 	} else {
-		exitNoCapture("%v\nError loading kubernetes version info.\nPlease check your environment for problems by running \"kubectl version\".\n", err)
+		exitWithCapture("%v\nError loading kubernetes version info.\nPlease check your environment for problems by running \"kubectl version\".\n", err)
 	}
 }

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -11,7 +11,7 @@ import (
 // Client implements a kubectl client to execute commands
 type Client interface {
 	Execute(args ...string) (string, error)
-	ExecuteOutputMatrix(args ...string) (string, string, string, error)
+	ExecuteOutputMatrix(args ...string) (stdout, stderr, combined string, err error)
 }
 
 // Execute executes kubectl <args> and returns the combined stdout/err output.

--- a/pkg/kubectl/kubectl_test.go
+++ b/pkg/kubectl/kubectl_test.go
@@ -27,9 +27,9 @@ func (t *TestClient) Execute(args ...string) (string, error) {
 	return "", fmt.Errorf("Missing response for %q", cmd)
 }
 
-func (t *TestClient) ExecuteOutputMatrix(args ...string) (string, string, string, error) {
-	out, err := Execute(t, args...)
-	return out, "", out, err
+func (t *TestClient) ExecuteOutputMatrix(args ...string) (stdout, stderr, combined string, err error) {
+	stdout, err = Execute(t, args...)
+	return stdout, "", stdout, err
 }
 
 func TestGetSecretValue(t *testing.T) {

--- a/pkg/kubectl/kubectl_test.go
+++ b/pkg/kubectl/kubectl_test.go
@@ -27,8 +27,9 @@ func (t *TestClient) Execute(args ...string) (string, error) {
 	return "", fmt.Errorf("Missing response for %q", cmd)
 }
 
-func (t *TestClient) ExecuteStdout(args ...string) (string, error) {
-	return Execute(t, args...)
+func (t *TestClient) ExecuteOutputMatrix(args ...string) (string, string, string, error) {
+	out, err := Execute(t, args...)
+	return out, "", out, err
 }
 
 func TestGetSecretValue(t *testing.T) {

--- a/pkg/kubectl/local.go
+++ b/pkg/kubectl/local.go
@@ -1,9 +1,12 @@
 package kubectl
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
+	"sync"
 )
 
 // LocalClient implements Kubectl
@@ -31,6 +34,38 @@ func (k LocalClient) Execute(args ...string) (string, error) {
 func (k LocalClient) ExecuteStdout(args ...string) (string, error) {
 	cmdOut, err := exec.Command("kubectl", append(k.GlobalArgs, args...)...).Output()
 	return string(cmdOut), err
+}
+
+// ExecuteOutputMatrix executes kubectl <args> and returns stdout, stderr, and the combined interleaved output.
+func (k LocalClient) ExecuteOutputMatrix(args ...string) (string, string, string, error) {
+	cmd := exec.Command("kubectl", append(k.GlobalArgs, args...)...)
+	return outputMatrix(cmd)
+}
+
+func outputMatrix(cmd *exec.Cmd) (string, string, string, error) {
+	var stdoutBuf, stderrBuf, combinedBuf bytes.Buffer
+	stdout, _ := cmd.StdoutPipe()
+	stderr, _ := cmd.StderrPipe()
+
+	stdoutWriter := io.MultiWriter(&combinedBuf, &stdoutBuf)
+	stderrWriter := io.MultiWriter(&combinedBuf, &stderrBuf)
+
+	var wg sync.WaitGroup
+	copy := func(dst io.Writer, src io.Reader) {
+		defer wg.Done()
+		_, _ = io.Copy(dst, src)
+	}
+
+	err := cmd.Start()
+	if err == nil {
+		wg.Add(2)
+		go copy(stdoutWriter, stdout)
+		go copy(stderrWriter, stderr)
+		// we need to wait for all reads to finish before calling cmd.Wait
+		wg.Wait()
+		err = cmd.Wait()
+	}
+	return string(stdoutBuf.Bytes()), string(stderrBuf.Bytes()), string(combinedBuf.Bytes()), err
 }
 
 func formatCmdOutput(output []byte) string {

--- a/pkg/kubectl/local_test.go
+++ b/pkg/kubectl/local_test.go
@@ -1,7 +1,10 @@
 package kubectl
 
 import (
+	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFormatCmdOutput(t *testing.T) {
@@ -24,4 +27,14 @@ func TestFormatCmdOutput(t *testing.T) {
 func ExampleLocalClient() {
 	local := LocalClient{}
 	local.Execute("apply", "-f", "service.yaml")
+}
+
+func TestOutputMatrix(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "echo stdout; sleep 0.001; echo stderr >&2; sleep 0.001; echo stdout")
+
+	stdout, stderr, combined, err := outputMatrix(cmd)
+	assert.Equal(t, "stdout\nstdout\n", stdout)
+	assert.Equal(t, "stderr\n", stderr)
+	assert.Equal(t, "stdout\nstderr\nstdout\n", combined)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Adds a util to capture stderr separately to the combined output, so that we can make better error messages.