### PR TITLE
Add DNS status check

### DIFF
--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -111,6 +111,20 @@ func mainImpl() {
 		}
 	}
 
+	if !opts.GKE {
+		dns, err := kubectl.DeploymentAvailability(kubectlClient, "kube-dns", "kube-system")
+		if err != nil {
+			exitWithCapture("There was an error with getting DNS deployment status %s\n", err)
+		}
+
+		// We exit if the DNS pods are not up and running, as the installer needs to be
+		// able to connect to the server to correctly setup the needed resources.
+		if !dns {
+			fmt.Println("WARNING: DNS pods are not up and running, launcher requires correct DNS setup in the Kubernetes cluster.")
+			os.Exit(1)
+		}
+	}
+
 	secretCreated, err := kubectl.CreateSecretFromLiteral(kubectlClient, "weave", "weave-cloud", "token", opts.Token, opts.AssumeYes)
 	if err != nil {
 		exitWithCapture("There was an error creating the secret: %s\n", err)


### PR DESCRIPTION
Sometimes DNS is not configured correctly, mainly on minikube
Kubernetes clusters. This checks that the DNS deployment has all
the running pods, if not it errors out and suggests to the user
to correctly setup DNS.

Fixes https://github.com/weaveworks/launcher/issues/158

Notes:
- I exit rather than just output the error, I noticed in the case of when GKE setup fails you just notify the user but do not abort, not sure which is the correct approach here?
- Was not sure if we should leave a suggestion on how the user should fix this? If so, which of the two options from the issue should we suggest?