### PR TITLE
Add DNS check to bootstrap

### DIFF
--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -111,6 +111,21 @@ func mainImpl() {
 		}
 	}
 
+	// TODO: Should we check always?
+	if !opts.GKE {
+		ok, err := kubectl.TestDNS(kubectlClient, "kubernetes.default.svc")
+		if err != nil {
+			exitWithCapture("There was an error while performing DNS check. %s\n", err)
+		}
+
+		// We exit if the DNS pods are not up and running, as the installer needs to be
+		// able to connect to the server to correctly setup the needed resources.
+		if !ok {
+			fmt.Println("DNS is not working in this Kubernetes cluster. We require correct DNS setup in the Kubernetes cluster.")
+			os.Exit(1)
+		}
+	}
+
 	secretCreated, err := kubectl.CreateSecretFromLiteral(kubectlClient, "weave", "weave-cloud", "token", opts.Token, opts.AssumeYes)
 	if err != nil {
 		exitWithCapture("There was an error creating the secret: %s\n", err)

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -111,19 +111,17 @@ func mainImpl() {
 		}
 	}
 
-	// TODO: Should we check always?
-	if !opts.GKE {
-		ok, err := kubectl.TestDNS(kubectlClient, "kubernetes.default.svc")
-		if err != nil {
-			exitWithCapture("There was an error while performing DNS check. %s\n", err)
-		}
+	// Perform a check to make sure DNS is working correctly.
+	ok, err := kubectl.TestDNS(kubectlClient, "kubernetes.default.svc")
+	if err != nil {
+		exitWithCapture("There was an error while performing DNS check. %s\n", err)
+	}
 
-		// We exit if the DNS pods are not up and running, as the installer needs to be
-		// able to connect to the server to correctly setup the needed resources.
-		if !ok {
-			fmt.Println("DNS is not working in this Kubernetes cluster. We require correct DNS setup in the Kubernetes cluster.")
-			os.Exit(1)
-		}
+	// We exit if the DNS pods are not up and running, as the installer needs to be
+	// able to connect to the server to correctly setup the needed resources.
+	if !ok {
+		fmt.Println("DNS is not working in this Kubernetes cluster. We require correct DNS setup in the Kubernetes cluster.")
+		os.Exit(1)
 	}
 
 	secretCreated, err := kubectl.CreateSecretFromLiteral(kubectlClient, "weave", "weave-cloud", "token", opts.Token, opts.AssumeYes)

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -120,8 +120,7 @@ func mainImpl() {
 	// We exit if the DNS pods are not up and running, as the installer needs to be
 	// able to connect to the server to correctly setup the needed resources.
 	if !ok {
-		fmt.Println("DNS is not working in this Kubernetes cluster. We require correct DNS setup in the Kubernetes cluster.")
-		os.Exit(1)
+		exitWithCapture("DNS is not working in this Kubernetes cluster. We require correct DNS setup in the Kubernetes cluster.")
 	}
 
 	secretCreated, err := kubectl.CreateSecretFromLiteral(kubectlClient, "weave", "weave-cloud", "token", opts.Token, opts.AssumeYes)

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -186,7 +186,7 @@ func TestDNS(c Client, domain string) (bool, error) {
 	}
 
 	// Create pod to perform nslookup on a passed domain to check DNS is working.
-	_, err = Execute(c, "run", "-n", "weave", "--image", "busybox", "--command", podName, "nslookup --timeout=10", domain, "--restart=Never", "--pod-running-timeout=10s")
+	_, err = Execute(c, "run", "-n", "weave", "--image", "busybox", "--command", podName, "nslookup --timeout=10", domain, "--restart=Never")
 	if err != nil {
 		return false, err
 	}

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -6,7 +6,21 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
+
+const (
+	podSuccess = "Succeeded"
+	podFailure = "Failed"
+)
+
+type pod struct {
+	Status status `json:"status"`
+}
+
+type status struct {
+	Phase string `json:"phase"`
+}
 
 // Client implements a kubectl client to execute commands
 type Client interface {
@@ -119,6 +133,120 @@ func ResourceExists(c Client, resourceType, namespace, resourceName string) (boo
 func DeleteResource(c Client, resourceType, namespace, resourceName string) error {
 	_, err := Execute(c, "delete", resourceType, resourceName, fmt.Sprintf("--namespace=%s", namespace))
 	return err
+}
+
+func isPodReady(c Client, podName, ns string) error {
+	// Timeout is set for 1 minute, as Kubernetes requires some time to create a pod.
+	timeout := time.After(1 * time.Minute)
+	tick := time.Tick(1 * time.Second)
+
+	for {
+		select {
+		case <-timeout:
+			return errors.New("Timed out during DNS check.")
+		case <-tick:
+			ok, err := checkPod(c, podName, ns)
+			if err != nil {
+				return err
+			} else if ok {
+				return nil
+			}
+		}
+	}
+}
+
+func checkPod(c Client, podName, ns string) (bool, error) {
+	// Retrieve current pod data.
+	podJSON, err := Execute(c, "get", "pod", podName, "-ojson", "-n", ns)
+	if err != nil {
+		return false, err
+	}
+	p := pod{}
+	err = json.Unmarshal([]byte(podJSON), &p)
+	if err != nil {
+		return false, err
+	}
+
+	if p.Status.Phase != podSuccess && p.Status.Phase != podFailure {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+//TestDNS creates a pod where a nslookup is called on a provided domain. It returns true only if the pod was successful.
+func TestDNS(c Client, domain string) (bool, error) {
+	podName := "launcher-pre-flight"
+	ns := "weave"
+
+	// Create weave namespace, as this happens before any resources are created.
+	_, err := CreateNamespace(c, ns)
+	if err != nil {
+		return false, err
+	}
+
+	// Create pod to perform nslookup on a passed domain to check DNS is working.
+	_, err = Execute(c, "run", "-n", "weave", "--image", "busybox", "--command", podName, "nslookup --timeout=10", domain, "--restart=Never", "--pod-running-timeout=10s")
+	if err != nil {
+		return false, err
+	}
+
+	// Initially fetch the pod, which was created above.
+	podJSON, err := Execute(c, "get", "pod", podName, "-ojson", "-n", ns)
+	if err != nil {
+		return false, err
+	}
+	p := pod{}
+	err = json.Unmarshal([]byte(podJSON), &p)
+	if err != nil {
+		return false, err
+	}
+
+	if p.Status.Phase != podSuccess && p.Status.Phase != podFailure {
+		// If the state has not been reached yet, we enter a retry phase.
+		// In isPodReady function we retry to get pod status phase for a minute and then timeout.
+		err := isPodReady(c, podName, ns)
+		// Either an error occurred or timeout was reached.
+		if err != nil {
+			// Attempt to cleanup pod.
+			_ = DeleteResource(c, "pod", ns, podName)
+			return false, fmt.Errorf("DNS check failed. %v", err)
+		}
+	}
+
+	// Get fresh pod data.
+	podJSON, err = Execute(c, "get", "pod", podName, "-ojson", "-n", ns)
+	if err != nil {
+		return false, err
+	}
+	err = json.Unmarshal([]byte(podJSON), &p)
+	if err != nil {
+		return false, err
+	}
+
+	// If the final status of the pod was failed, we should return an error as DNS is not working.
+	if p.Status.Phase == podFailure {
+		err = DeleteResource(c, "pod", ns, podName)
+		if err != nil {
+			return false, err
+		}
+		return false, fmt.Errorf("DNS check failed. The DNS in the Kuberentes cluster is not working correctly.")
+	}
+
+	// This should not happen but still lets error out in case it does.
+	if p.Status.Phase != podSuccess {
+		return false, fmt.Errorf("DNS check failed.")
+	}
+
+	// Cleanup the pod.
+	err = DeleteResource(c, "pod", ns, podName)
+	if err != nil {
+		// We should still return that DNS works, there was only a problem with deleting the resource.
+		return true, err
+	}
+
+	// We are certain that pod is up and running so we return DNS okay.
+	return true, nil
 }
 
 // CreateNamespace creates a new namespace and returns whether it was created or not

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -33,6 +33,11 @@ func Execute(c Client, args ...string) (string, error) {
 	return c.Execute(args...)
 }
 
+// ExecuteJSON execute kubectl <args> and returns the combined json stdout and err output.
+func ExecuteJSON(c client, args ...string) (string, error) {
+	return c.Execute(append(args, "-ojson"))
+}
+
 // ClusterInfo describes a Kubernetes cluster
 type ClusterInfo struct {
 	Name          string
@@ -157,7 +162,7 @@ func isPodReady(c Client, podName, ns string) error {
 
 func checkPod(c Client, podName, ns string) (bool, error) {
 	// Retrieve current pod data.
-	podJSON, err := Execute(c, "get", "pod", podName, "-ojson", "-n", ns)
+	podJSON, err := ExecuteJSON(c, "get", "pod", podName, "-n", ns)
 	if err != nil {
 		return false, err
 	}
@@ -192,7 +197,7 @@ func TestDNS(c Client, domain string) (bool, error) {
 	}
 
 	// Initially fetch the pod, which was created above.
-	podJSON, err := Execute(c, "get", "pod", podName, "-ojson", "-n", ns)
+	podJSON, err := ExecuteJSON(c, "get", "pod", podName, "-n", ns)
 	if err != nil {
 		return false, err
 	}
@@ -215,7 +220,7 @@ func TestDNS(c Client, domain string) (bool, error) {
 	}
 
 	// Get fresh pod data.
-	podJSON, err = Execute(c, "get", "pod", podName, "-ojson", "-n", ns)
+	podJSON, err = ExecuteJSON(c, "get", "pod", podName, "-n", ns)
 	if err != nil {
 		return false, err
 	}
@@ -324,7 +329,7 @@ type secretManifest struct {
 
 // GetSecretValue returns the value of a secret
 func GetSecretValue(c Client, namespace, name, key string) (string, error) {
-	output, err := Execute(c, "get", "secret", name, fmt.Sprintf("--namespace=%s", namespace), "--output=json")
+	output, err := ExecuteJSON(c, "get", "secret", name, fmt.Sprintf("--namespace=%s", namespace))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Sometimes DNS is not configured correctly, but during the launcher
process, DNS is required to setup all the needed resources. This creates
a check by creating a pod where nslookup is performed.

Closes https://github.com/weaveworks/launcher/issues/158.

*Note:* Opened as more of a preview PR, if we agree on this implementation will add a test or two to this PR. :)