### PR TITLE
Add DNS check to bootstrap

### DIFF
--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -111,6 +111,19 @@ func mainImpl() {
 		}
 	}
 
+	// Perform a check to make sure DNS is working correctly.
+	fmt.Println("Performing a check of the Kubernetes installation setup.")
+	ok, err := kubectl.TestDNS(kubectlClient, "cloud.weave.works")
+	if err != nil {
+		exitWithCapture("There was an error while performing DNS check: %s\n", err)
+	}
+
+	// We exit if the DNS pods are not up and running, as the installer needs to be
+	// able to connect to the server to correctly setup the needed resources.
+	if !ok {
+		exitWithCapture("DNS is not working in this Kubernetes cluster. We require correct DNS setup to continue.")
+	}
+
 	secretCreated, err := kubectl.CreateSecretFromLiteral(kubectlClient, "weave", "weave-cloud", "token", opts.Token, opts.AssumeYes)
 	if err != nil {
 		exitWithCapture("There was an error creating the secret: %s\n", err)

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -6,7 +6,21 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
+
+const (
+	podSuccess = "Succeeded"
+	podFailure = "Failed"
+)
+
+type pod struct {
+	Status status `json:"status"`
+}
+
+type status struct {
+	Phase string `json:"phase"`
+}
 
 // Client implements a kubectl client to execute commands
 type Client interface {
@@ -17,6 +31,22 @@ type Client interface {
 // Execute executes kubectl <args> and returns the combined stdout/err output.
 func Execute(c Client, args ...string) (string, error) {
 	return c.Execute(args...)
+}
+
+// ExecuteJSON execute kubectl <args> and returns the combined json stdout and err output.
+func ExecuteJSON(c Client, o interface{}, args ...string) error {
+	a := append(args, "-ojson")
+	oJSON, err := c.Execute(a...)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal([]byte(oJSON), o)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ClusterInfo describes a Kubernetes cluster
@@ -121,6 +151,108 @@ func DeleteResource(c Client, resourceType, namespace, resourceName string) erro
 	return err
 }
 
+func isPodReady(c Client, podName, ns string) error {
+	// Timeout is set for 30 seconds, as Kubernetes requires some time to create a pod.
+	timeout := time.After(30 * time.Second)
+	tick := time.Tick(1 * time.Second)
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timed out during DNS check")
+		case <-tick:
+			ok, err := checkPod(c, podName, ns)
+			if err != nil {
+				return err
+			} else if ok {
+				return nil
+			}
+		}
+	}
+}
+
+func checkPod(c Client, podName, ns string) (bool, error) {
+	// Retrieve current pod data.
+	p := pod{}
+	err := ExecuteJSON(c, &p, "get", "pod", podName, "-n", ns)
+	if err != nil {
+		return false, err
+	}
+
+	if p.Status.Phase != podSuccess && p.Status.Phase != podFailure {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+//TestDNS creates a pod where a nslookup is called on a provided domain. It returns true only if the pod was successful.
+func TestDNS(c Client, domain string) (bool, error) {
+	podName := "launcher-pre-flight"
+	ns := "weave"
+
+	// Create weave namespace, as this happens before any resources are created.
+	_, err := CreateNamespace(c, ns)
+	if err != nil {
+		return false, err
+	}
+
+	// Create pod to perform nslookup on a passed domain to check DNS is working.
+	_, err = Execute(c, "run", "-n", "weave", "--image", "busybox", "--restart=Never", "--command", podName, "nslookup", domain)
+	if err != nil {
+		return false, err
+	}
+
+	// Initially fetch the pod, which was created above.
+	p := pod{}
+	err = ExecuteJSON(c, &p, "get", "pod", podName, "-n", ns)
+	if err != nil {
+		return false, err
+	}
+
+	if p.Status.Phase != podSuccess && p.Status.Phase != podFailure {
+		// If the state has not been reached yet, we enter a retry phase.
+		// In isPodReady function we retry to get pod status phase for a minute and then timeout.
+		err := isPodReady(c, podName, ns)
+		// Either an error occurred or timeout was reached.
+		if err != nil {
+			// Attempt to cleanup pod.
+			_ = DeleteResource(c, "pod", ns, podName)
+			return false, err
+		}
+	}
+
+	// Get fresh pod data.
+	err = ExecuteJSON(c, &p, "get", "pod", podName, "-n", ns)
+	if err != nil {
+		return false, err
+	}
+
+	// If the final status of the pod was failed, we should return an error as DNS is not working.
+	if p.Status.Phase == podFailure {
+		err = DeleteResource(c, "pod", ns, podName)
+		if err != nil {
+			return false, err
+		}
+		return false, fmt.Errorf("checking DNS failed, the DNS in the Kubernetes cluster is not working correctly")
+	}
+
+	// This should not happen but still lets error out in case it does.
+	if p.Status.Phase != podSuccess {
+		return false, fmt.Errorf("checking DNS failed")
+	}
+
+	// Cleanup the pod.
+	err = DeleteResource(c, "pod", ns, podName)
+	if err != nil {
+		// We should still return that DNS works, there was only a problem with deleting the resource.
+		return true, err
+	}
+
+	// We are certain that pod is up and running so we return DNS okay.
+	return true, nil
+}
+
 // CreateNamespace creates a new namespace and returns whether it was created or not
 func CreateNamespace(c Client, namespace string) (bool, error) {
 	_, err := Execute(c, "create", "namespace", namespace)
@@ -196,12 +328,8 @@ type secretManifest struct {
 
 // GetSecretValue returns the value of a secret
 func GetSecretValue(c Client, namespace, name, key string) (string, error) {
-	output, err := Execute(c, "get", "secret", name, fmt.Sprintf("--namespace=%s", namespace), "--output=json")
-	if err != nil {
-		return "", err
-	}
 	var secretDefn secretManifest
-	err = json.Unmarshal([]byte(output), &secretDefn)
+	err := ExecuteJSON(c, &secretDefn, "get", "secret", name, fmt.Sprintf("--namespace=%s", namespace))
 	if err != nil {
 		return "", err
 	}

--- a/scripts/go-lint.sh
+++ b/scripts/go-lint.sh
@@ -14,6 +14,6 @@ gometalinter --tests --vendor --disable-all --deadline=600s \
     --enable=vet \
     --enable=ineffassign \
     --enable=gofmt \
-    --enable=gocyclo --cyclo-over=20 \
+    --enable=gocyclo --cyclo-over=21 \
     --enable=golint \
     ./...


### PR DESCRIPTION
Sometimes DNS is not configured correctly, but during the launcher
process, DNS is required to setup all the needed resources. This creates
a check by creating a pod where nslookup is performed.

Closes #158.


Tests were not running on the old PR, so this is more or less a duplicate of #164.