### PR TITLE
Validate minimum Kubernetes cluster version 1.6.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,6 +32,12 @@
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  name = "github.com/blang/semver"
+  packages = ["."]
+  revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
+  version = "v3.5.1"
+
+[[projects]]
   name = "github.com/certifi/gocertifi"
   packages = ["."]
   revision = "deb3ae2ef2610fde3330947281941c562861188b"
@@ -769,6 +775,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "546efbffebe90295f64c651c458a1f66c8106c688334f30e7405c416bc1f3936"
+  inputs-digest = "f15aca53c593246dfbd4e543acb119de22e2ceb0e542b070935b81659026c00f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/kubectl/kubectl_test.go
+++ b/pkg/kubectl/kubectl_test.go
@@ -36,7 +36,7 @@ func TestGetSecretValue(t *testing.T) {
 	tc := NewTestClient()
 
 	json := `{"data":{"token": "c2VjcmV0IQ=="}}`
-	tc.responses["get secret weave-cloud --namespace=weave --output=json"] = json
+	tc.responses["get secret weave-cloud --namespace=weave -ojson"] = json
 	res, err := GetSecretValue(tc, "weave", "weave-cloud", "token")
 	assert.Equal(t, res, "secret!")
 	assert.NoError(t, err)


### PR DESCRIPTION
As agreed in https://github.com/weaveworks/launcher/issues/162 we want to support cluster of 1.6.0 and above.
Because semantic versioning is hard (when handling things like alpha versions, etc.) and can become complicated I didn't want to re-write an entire parser so I choose to use https://github.com/blang/semver.


Closes https://github.com/weaveworks/launcher/issues/162

Note:
I did some testing and I ran into some problems as described on slack when using v1.6.0:
```
There was an error applying the agent: Error from server (NotFound): the server could not find the requested resource
Full output:
Error from server (NotFound): the server could not find the requested resource
Rolling back cluster changes
```
Not sure if this is related to DNS, or something else but maybe we should explore this more at some point? But in general I checked the things we use and kube-state-metrics, scope, prometheus, etc. should be working fine with 1.6.0+.