### PR TITLE
Pass flag to always skip checking certs validity

### DIFF
--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -56,6 +56,9 @@ func mainImpl() {
 		"weave_cloud_hostname": opts.WCHostname,
 	})
 
+	// Due to some users Kubernetes clusters having invalid, e.g. self-signed,
+	// certificates, we default to skipping the certificate validation.
+	otherArgs = append(otherArgs, "--insecure-skip-tls-verify")
 	kubectlClient := kubectl.LocalClient{
 		GlobalArgs: otherArgs,
 	}


### PR DESCRIPTION
This is needed due to the reported problems with users kubernetes
clusters having unsigned certificates.

Closes https://github.com/weaveworks/launcher/issues/173