### PR TITLE
don't combine stdout & stderr in gcloud execution

### DIFF
--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -12,7 +12,7 @@ func IsPresent() bool {
 }
 
 func executeCommand(args ...string) (string, error) {
-	cmdOut, err := exec.Command("gcloud", args...).CombinedOutput()
+	cmdOut, err := exec.Command("gcloud", args...).Output()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
gcloud prints various informative messages to stderr, which breaks our output processing.

Fixes #177