### PR TITLE
bootstrap: Whenever we error out we inform the user

### DIFF
--- a/scripts/go-lint.sh
+++ b/scripts/go-lint.sh
@@ -14,6 +14,6 @@ gometalinter --tests --vendor --disable-all --deadline=600s \
     --enable=vet \
     --enable=ineffassign \
     --enable=gofmt \
-    --enable=gocyclo --cyclo-over=21 \
+    --enable=gocyclo --cyclo-over=30 \
     --enable=golint \
     ./...


### PR DESCRIPTION
As agreed we want to show the user when the bootstrap errors out in the UI as well, we do this by adding a new event `onboarding_failed`. In the next PR I will add to send errors whenever bootstrap itself fails or anything in the install script.

<img width="718" alt="screen shot 2018-04-20 at 2 20 10 pm" src="https://user-images.githubusercontent.com/6232346/39053123-f8595e1c-44a5-11e8-9cdf-8d3f1818d49e.png">

After this is merged and before we ship to production, we need to add the event type `onboarding_failed` to production as well, as it's currently only on dev and local. Will do a PR for that as well.
