### PR TITLE
Send all errors that occur in the install script

### DIFF
--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -182,7 +182,9 @@ func capture(skipFrames uint, msg string, args ...interface{}) {
 
 func exitWithCapture(msg string, args ...interface{}) {
 	capture(2, msg, args...)
-	os.Exit(1)
+	// Exit with a specific error which will be checked against in install script,
+	// as a way of deduplicating sending of these errors.
+	os.Exit(111)
 }
 
 func createGKEClusterRoleBinding(kubectlClient kubectl.Client) error {

--- a/service/static/install.sh
+++ b/service/static/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # Create a temporary file for the bootstrap binary
@@ -45,7 +45,7 @@ if [ "$unamestr" = 'Darwin' ]; then
 elif [ "$unamestr" = 'Linux' ]; then
     dist='linux'
 else
-  echo "This distribution is not supported"
+  echo "This OS is not supported"
   exit 1
 fi
 


### PR DESCRIPTION
This also adds a reserved error code 111 to bootstrap, which is used to
exclude the errors, so we only send the only produced in the script
itself.