### PR TITLE
Error out when user lacks GKE cluster permission

### DIFF
--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -113,8 +113,11 @@ func mainImpl() {
 			raven.SetTagsContext(map[string]string{
 				"gke_clusterrolebindingError": err.Error(),
 			})
-			fmt.Fprintln(os.Stderr, "WARNING: For GKE installations, a cluster-admin clusterrolebinding is required.")
-			fmt.Fprintf(os.Stderr, "Could not create clusterrolebinding: %s\n", err)
+
+			errText := err.Error()
+			if strings.Contains(errText, "Forbidden") || strings.Contains(errText, "forbidden") {
+				exitWithCapture(opts, "Could not create clusterrolebinding. GKE role \"Kubernetes Engine Admin\" (containers.admin) required to create resources.\n%s\n", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
The minimum role needed to create clusterrolebinding is the
"containers.admin" role.

This is how the actual full error looks like:
```
Could not create clusterrolebinding. GKE role "containers.admin" required to create resources.
Error from server (Forbidden): clusterrolebindings.rbac.authorization.k8s.io is forbidden: User "lili" cannot create clusterrolebindings.rbac.authorization.k8s.io at the cluster scope: Required "container.clusterRoleBindings.create" permission.
Full output:
Error from server (Forbidden): clusterrolebindings.rbac.authorization.k8s.io is forbidden: User "lili" cannot create clusterrolebindings.rbac.authorization.k8s.io at the cluster scope: Required "container.clusterRoleBindings.create" permission.
```

Open to suggestions about if we should include the k8s errors, or does it make it harder to see the actual error we send?