### PR TITLE
Run agent build job for tag pushes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,10 @@ workflows:
   build_deploy:
     jobs:
       - global_tests
-      - agent
+      - agent:
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*(-[a-z]+)?/
       - bootstrap
       - service
       - integration_install_update_flow:


### PR DESCRIPTION
CircleCI requires `filters` `tag` to execute jobs on tagged pushes. https://circleci.com/docs/2.0/workflows/#git-tag-job-execution

Only run the `agent` job because we are tagging releases from master manually and we only need to push the image.

Allows https://github.com/weaveworks/launcher/pull/192 to run.