### PR TITLE
Add org.opencontainers.image.* labels to Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ docker/Dockerfile.service: docker/Dockerfile.service.in Makefile
 build/.%.done: docker/Dockerfile.%
 	mkdir -p ./build/docker/$*
 	cp -r $^ ./build/docker/$*/
-	${DOCKER} build -t quay.io/weaveworks/launcher-$* -t quay.io/weaveworks/launcher-$*:$(IMAGE_TAG) -f build/docker/$*/Dockerfile.$* ./build/docker/$*
+	${DOCKER} build --build-arg=revision=$(GIT_HASH) -t quay.io/weaveworks/launcher-$* -t quay.io/weaveworks/launcher-$*:$(IMAGE_TAG) -f build/docker/$*/Dockerfile.$* ./build/docker/$*
 	touch $@
 
 #

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,7 +1,13 @@
 FROM alpine:3.7
-LABEL maintainer="Weaveworks Inc <help@weave.works>"
 RUN apk add --no-cache ca-certificates
 COPY ./agent /usr/bin/launcher-agent
 COPY ./kubectl /usr/bin/kubectl
 ENTRYPOINT ["/usr/bin/launcher-agent"]
 CMD ["-help"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="launcher-agent" \
+      org.opencontainers.image.source="https://github.com/weaveworks/launcher" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/docker/Dockerfile.service.in
+++ b/docker/Dockerfile.service.in
@@ -1,5 +1,4 @@
 FROM alpine:3.7
-MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /
 COPY service /launcher-service
 RUN mkdir static
@@ -7,3 +6,10 @@ COPY static/install.sh /static/
 COPY static/agent.yaml /static/
 EXPOSE 80
 ENTRYPOINT ["/launcher-service", "--bootstrap-version=@@GIT_HASH@@"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="launcher-service" \
+      org.opencontainers.image.source="https://github.com/weaveworks/launcher" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/integration-tests/docker/Dockerfile.nginx-bootstrap
+++ b/integration-tests/docker/Dockerfile.nginx-bootstrap
@@ -3,3 +3,9 @@ EXPOSE 80
 ARG version
 RUN mkdir -p /usr/share/nginx/html/bootstrap/${version}
 COPY ./bootstrap/* /usr/share/nginx/html/bootstrap/${version}/
+
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="launcher-integration-tests" \
+      org.opencontainers.image.source="https://github.com/weaveworks/launcher/tree/master/integration-tests" \
+      org.opencontainers.image.revision="${version}" \
+      org.opencontainers.image.vendor="Weaveworks"


### PR DESCRIPTION
Why? What?

- This should ultimately help for image-to-code back references.
- `org.label-schema.*` labels are now deprecated, in favour of `org.opencontainers.image.*` labels.
  See also: https://github.com/opencontainers/image-spec/blob/master/annotations.md#back-compatibility-with-label-schema
- `MAINTAINER` is deprecated, in favour of the `maintainer` label.
 - Git revision is now injected at `docker build` time.

Testing:

```console
$ docker inspect quay.io/weaveworks/launcher-agent
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.opencontainers.image.revision": "dbd70c8482ef23d11f434c6b7e7fde9f7c7b3a62",
                "org.opencontainers.image.source": "https://github.com/weaveworks/launcher",
                "org.opencontainers.image.title": "launcher-agent",
                "org.opencontainers.image.vendor": "Weaveworks"
            }
[...]

$ docker inspect quay.io/weaveworks/launcher-service
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.opencontainers.image.revision": "dbd70c8482ef23d11f434c6b7e7fde9f7c7b3a62",
                "org.opencontainers.image.source": "https://github.com/weaveworks/launcher",
                "org.opencontainers.image.title": "launcher-service",
                "org.opencontainers.image.vendor": "Weaveworks"
            }
[...]
```
