### PR TITLE
Expose prom metrics for k8s events

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -373,13 +373,13 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
     "prometheus/promhttp"
   ]
-  revision = "82f5ff156b29e276022b1a958f7d385870fb9814"
+  revision = "967789050ba94deca04a5e84cce8ad472ce313c1"
+  version = "v0.9.0-pre1"
 
 [[projects]]
   branch = "master"
@@ -778,6 +778,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4a9ac90bb72ea90de772c1326b6230fddba005f7265571f5bafbd8dd3dc3c2bb"
+  inputs-digest = "6807a25f51b8ed595b501528034f0e8f37378a64aa6301c531d2509ff1708bef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -375,8 +375,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus"]
-  revision = "9bb6ab929dcbe1c8393cd9ef70387cb69811bd1c"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
+  revision = "82f5ff156b29e276022b1a958f7d385870fb9814"
 
 [[projects]]
   branch = "master"
@@ -775,6 +778,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f15aca53c593246dfbd4e543acb119de22e2ceb0e542b070935b81659026c00f"
+  inputs-digest = "4a9ac90bb72ea90de772c1326b6230fddba005f7265571f5bafbd8dd3dc3c2bb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -83,8 +83,8 @@ branch = "release-1.9"
   name = "github.com/docker/distribution"
   branch = "master"
 
-# Pin to master branch until there is a more recent stable release:
+# Pin to v0.9.0-pre1 until there is a more recent stable release:
 #   https://github.com/prometheus/client_golang/issues/375
 [[constraint]]
   name = "github.com/prometheus/client_golang"
-  branch = "master"
+  version = "v0.9.0-pre1"

--- a/agent/main.go
+++ b/agent/main.go
@@ -75,7 +75,7 @@ func updateAgents(cfg *agentConfig, cancel <-chan interface{}) {
 	// Self-update
 	agentPollURL, err := text.ResolveString(cfg.AgentPollURLTemplate, cfg)
 	if err != nil {
-		log.Fatal("invalid URL template:", err)
+		log.Fatal("invalid URL template: ", err)
 	}
 	log.Info("Updating self from ", agentPollURL)
 
@@ -134,7 +134,7 @@ func updateAgents(cfg *agentConfig, cancel <-chan interface{}) {
 	// Update Weave Cloud agents
 	wcPollURL, err := text.ResolveString(cfg.WCPollURLTemplate, cfg)
 	if err != nil {
-		log.Fatal("invalid URL template:", err)
+		log.Fatal("invalid URL template: ", err)
 	}
 	log.Info("Updating WC from ", wcPollURL)
 	err = kubectl.Apply(cfg.KubectlClient, wcPollURL)

--- a/agent/main.go
+++ b/agent/main.go
@@ -145,7 +145,7 @@ func updateAgents(cfg *agentConfig, cancel <-chan interface{}) {
 }
 
 func setupKubeClient() (*kubeclient.Clientset, error) {
-	kubeConfig, err := k8s.GetClientConfig(&k8s.ClientConfig{
+	kubeConfig, err := k8s.NewClientConfig(&k8s.ClientConfig{
 		// We have seen quite a few clusters in the wild with invalid certificates.
 		// Disable checking certificates as a result.
 		Insecure: true,

--- a/kubernetes/agent-debug-events.yaml
+++ b/kubernetes/agent-debug-events.yaml
@@ -33,5 +33,6 @@ items:
               imagePullPolicy: IfNotPresent
               args:
               - -feature.install-agents=false
+              - -feature.kubernetes-events=true
               - -wc.token=foo
               - -log.level=debug

--- a/kubernetes/agent-debug-events.yaml
+++ b/kubernetes/agent-debug-events.yaml
@@ -31,6 +31,8 @@ items:
             - name: agent
               image: quay.io/weaveworks/launcher-agent:latest
               imagePullPolicy: IfNotPresent
+              ports:
+              - containerPort: 8080
               args:
               - -feature.install-agents=false
               - -feature.kubernetes-events=true

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -49,6 +49,10 @@ func homeDirectory() string {
 
 // kubeconfigPath returns the default kubeconfig location.
 func kubeconfigPath() string {
+	if env := os.Getenv("KUBECONFIG"); env != "" {
+		return env
+	}
+
 	home := homeDirectory()
 	if home == "" {
 		return ""

--- a/pkg/k8s/events.go
+++ b/pkg/k8s/events.go
@@ -19,13 +19,14 @@ const (
 )
 
 var (
-	totalEventsNum = prometheus.NewCounter(
+	totalEventsNum = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "launcher",
 			Subsystem: "events",
 			Name:      "total",
 			Help:      "The total number of events.",
-		})
+		},
+		[]string{"type", "involved_object", "reason"})
 )
 
 func init() {
@@ -54,7 +55,9 @@ event_loop:
 		}
 	}
 
-	totalEventsNum.Add(float64(len(events)))
+	for _, event := range events {
+		totalEventsNum.WithLabelValues(event.Type, event.InvolvedObject.Kind, event.Reason).Inc()
+	}
 
 	return events
 }

--- a/pkg/k8s/events.go
+++ b/pkg/k8s/events.go
@@ -32,14 +32,14 @@ func init() {
 	prometheus.MustRegister(totalEventsNum)
 }
 
-// EventSource produces kubernetes events.
+// EventSource produces Kubernetes events.
 type EventSource struct {
 	// Large local buffer, periodically read.
 	localEventsBuffer chan *apiv1.Event
 	eventClient       kubev1core.EventInterface
 }
 
-// GetNewEvents returns the kubernetes events that have been fired since the
+// GetNewEvents returns the Kubernetes events that have been fired since the
 // previous invocation of the function.
 func (source *EventSource) GetNewEvents() []*apiv1.Event {
 	// Get all data from the buffer.
@@ -137,7 +137,7 @@ func (source *EventSource) watch(cancel <-chan interface{}) {
 	}
 }
 
-// NewEventSource listens to kuberentes events in namespace. Call GetNewEvents
+// NewEventSource listens to kubernetes events in namespace. Call GetNewEvents
 // periodically to retrieve batches of events.
 func NewEventSource(client *kubeclient.Clientset, namespace string) *EventSource {
 	eventClient := client.CoreV1().Events(namespace)


### PR DESCRIPTION
I'd like to gather prometheus metrics on how many k8s events are fired in dev so we can decide how we'd store k8s events if we were to send them to weave cloud.

This PR does just that, with a bit of cleanup fixes here and there. Installing WC looks like:

```
launcher_events_total{involved_object="DaemonSet",reason="SuccessfulCreate",type="Normal"} 2
launcher_events_total{involved_object="Deployment",reason="ScalingReplicaSet",type="Normal"} 5
launcher_events_total{involved_object="Node",reason="FailedToStartNodeHealthcheck",type="Warning"} 1
launcher_events_total{involved_object="Pod",reason="Created",type="Normal"} 9
launcher_events_total{involved_object="Pod",reason="Pulled",type="Normal"} 9
launcher_events_total{involved_object="Pod",reason="SandboxChanged",type="Normal"} 1
launcher_events_total{involved_object="Pod",reason="Scheduled",type="Normal"} 6
launcher_events_total{involved_object="Pod",reason="Started",type="Normal"} 9
launcher_events_total{involved_object="Pod",reason="SuccessfulMountVolume",type="Normal"} 15
launcher_events_total{involved_object="ReplicaSet",reason="SuccessfulCreate",type="Normal"} 5
```

Also, we can now test the agent outside of the cluster, for instance, for this PR:

```
./build/agent -wc.token=foo -feature.install-agents=false -feature.kubernetes-events=true -log.level=debug
```
