### PR TITLE
agent: Don't require a token when not installing agents

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -188,7 +188,7 @@ func mainImpl() {
 		log.Fatal(err)
 	}
 
-	if *wcToken == "" {
+	if *featureInstall && *wcToken == "" {
 		log.Fatal("missing Weave Cloud instance token, provide one with -wc.token")
 	}
 

--- a/kubernetes/agent-debug-events.yaml
+++ b/kubernetes/agent-debug-events.yaml
@@ -36,5 +36,4 @@ items:
               args:
               - -feature.install-agents=false
               - -feature.kubernetes-events=true
-              - -wc.token=foo
               - -log.level=debug


### PR DESCRIPTION
We don't need a token when not installing anything on the cluster. Reflect that
in the argument parsing code.

More could be done if featureInstall is false, ie don't attempt migration steps
or contact WC at all, but given it's a debug only flag, may not worth the time!