### PR TITLE
bootstrap: Bump the DNS test timeout to 1m

### DIFF
--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -204,7 +204,7 @@ func DeleteResource(c Client, resourceType, namespace, resourceName string) erro
 
 func isPodReady(c Client, podName, ns string) error {
 	// Timeout is set for 30 seconds, as Kubernetes requires some time to create a pod.
-	timeout := time.After(30 * time.Second)
+	timeout := time.After(1 * time.Minute)
 	tick := time.Tick(1 * time.Second)
 
 	for {


### PR DESCRIPTION
We have seen in the wild a otherwise perfectly working k8s hit the 30s timeout
(it typically takes 3s in our dev cluster). When the check is skipped the rest
of the installation happens flowlessly.

Bump the timeout to 1m to leave more time for the test to run.