### PR TITLE
circleci: Bump up k8s cluster in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,16 +88,16 @@ jobs:
           name: Install integration test dependencies
           command: |
             # Install kubectl
-            curl --retry 5 -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+            curl --retry 5 -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
             # Install minikube
-            curl --retry 5 -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+            curl --retry 5 -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
             # Install yq
             curl --retry 5 -Lo yq https://github.com/mikefarah/yq/releases/download/1.14.0/yq_linux_amd64 && chmod +x yq && sudo mv yq /usr/local/bin/
       - &start_minikube
         run:
           name: Start minikube
           command: |
-            sudo minikube start --vm-driver=none
+            sudo minikube start --vm-driver=none --kubernetes-version v1.9.4
             sudo chown -R $USER.$USER ~/.minikube
             sudo chown -R $USER.$USER ~/.kube
             minikube update-context


### PR DESCRIPTION
Pin to 1.9.0 cluster and update kubectl and minikube releases we use.