### PR TITLE
agent: add fallback to k8s GitVersion

### DIFF
--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestGetMinorMajorVersion(t *testing.T) {
+	cases := []struct {
+		majorVersion string
+		minorVersion string
+		gitVersion   string
+		version      string
+		err          error
+	}{
+		{"1", "", "v1.9.0", "v1.9", nil},
+		{"1", "9", "v1.9.0", "v1.9", nil},
+		{"", "", "v", "", errors.New("kubernetes version not formatted correctly")},
+	}
+
+	for _, c := range cases {
+		v, err := getMajorMinorVersion(c.majorVersion, c.minorVersion, c.gitVersion)
+		if err != nil {
+
+			if c.err != nil {
+				if e, a := c.err, err; !reflect.DeepEqual(e, a) {
+					t.Errorf("Unexpected error; expected %v, got %v", e, a)
+					return
+				}
+				return
+			}
+			t.Error(err)
+			return
+		}
+		if v != c.version {
+			t.Errorf("Version was wrongl expected: %s got %s", c.version, v)
+		}
+	}
+}


### PR DESCRIPTION
In some cases the minor and major versions are not set, so when forming
the Cloudwatch URL we want to fallback to using the GitVersion.

Closes https://github.com/weaveworks/launcher/issues/218