### PR TITLE
build: Add timeouts to integration steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
             sleep 30
       - run:
           name: Execute integration tests
+          no_output_timeout: 2m
           command: |
             if [ -z "${CIRCLE_TAG}" -a "${CIRCLE_BRANCH}" == "master" ]; then
               export SERVICE_IMAGE="quay.io/weaveworks/launcher-service:$(docker/image-tag)"
@@ -137,6 +138,7 @@ jobs:
       - <<: *wait_for_k8s
       - run:
           name: Execute integration tests
+          no_output_timeout: 2m
           command: |
             if [ -z "${CIRCLE_TAG}" -a "${CIRCLE_BRANCH}" == "master" ]; then
               export SERVICE_IMAGE="quay.io/weaveworks/launcher-service:$(docker/image-tag)"
@@ -157,6 +159,7 @@ jobs:
       - <<: *wait_for_k8s
       - run:
           name: Execute integration tests
+          no_output_timeout: 2m
           command: |
             if [ -z "${CIRCLE_TAG}" -a "${CIRCLE_BRANCH}" == "master" ]; then
               export SERVICE_IMAGE="quay.io/weaveworks/launcher-service:$(docker/image-tag)"
@@ -184,6 +187,7 @@ jobs:
       - <<: *wait_for_k8s
       - run:
           name: Execute integration tests
+          no_output_timeout: 2m
           command: |
             if [ -z "${CIRCLE_TAG}" -a "${CIRCLE_BRANCH}" == "master" ]; then
               export SERVICE_IMAGE="quay.io/weaveworks/launcher-service:$(docker/image-tag)"

--- a/integration-tests/common.sh
+++ b/integration-tests/common.sh
@@ -1,23 +1,21 @@
 #!/bin/bash -e
 
 wait_for_service () {
-    echo -n "• Wait for launcher/service pod to become ready"
+    echo "• Wait for launcher/service pod to become ready"
     JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
-    until kubectl get pods -l name=service -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do echo -n .; sleep 1; done
-    echo
-    echo -n "• Wait for launcher/service to be fully reachable"
-    until curl -Ls $(minikube service service --url) > /dev/null 2>/dev/null ; do echo -n .; sleep 1; done
-    echo
+    until kubectl get pods -l name=service -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+
+    echo "• Wait for launcher/service to be fully reachable"
+    until curl -Ls $(minikube service service --url) > /dev/null 2>/dev/null; do sleep 1; done
 }
 
 wait_for_wc_agents () {
     echo -n "• Wait for weave pods to become ready"
     for name in weave-agent kube-state-metrics prom-node-exporter prometheus weave-flux-agent weave-flux-memcached weave-scope-agent
     do
-        echo -n "    • Wait for weave/$name"
+        echo "    • Wait for weave/$name"
         JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
-        until kubectl get pods -n weave -l name=$name -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do echo -n .; sleep 1; done
-        echo
+        until kubectl get pods -n weave -l name=$name -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
     done
 }
 


### PR DESCRIPTION
We have tests that fail, waiting for hours. We should properly timeout instead!

@LiliC suggested to use the built-in circle timeout instead of changing the waiting logic.

Cicle 2.0 only has the no_output_timeout key though. To make it work, we remove the '.' we printed for each iteration of the wait loop.

An example of test failing the timeout (I set it to 2s in that case for testing purposes): https://circleci.com/gh/weaveworks/launcher/9448?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Fixes: #68