### PR TITLE
ci: Change deployments apiVersion to apps/v1

### DIFF
--- a/integration-tests/k8s/nginx-bootstrap.yaml.in
+++ b/integration-tests/k8s/nginx-bootstrap.yaml.in
@@ -10,12 +10,15 @@ spec:
   selector:
     name: nginx-bootstrap
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-bootstrap
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: nginx-bootstrap
   revisionHistoryLimit: 2
   template:
     metadata:

--- a/integration-tests/k8s/service.updated.yaml.in
+++ b/integration-tests/k8s/service.updated.yaml.in
@@ -10,12 +10,15 @@ spec:
   selector:
     name: service
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: service
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: service
   revisionHistoryLimit: 2
   template:
     metadata:

--- a/integration-tests/k8s/service.yaml.in
+++ b/integration-tests/k8s/service.yaml.in
@@ -10,12 +10,15 @@ spec:
   selector:
     name: service
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: service
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: service
   revisionHistoryLimit: 2
   template:
     metadata:


### PR DESCRIPTION
We have some flaky tests that output:

  Error from server (BadRequest):
  error when creating "./integration-tests/tests/../k8s/service.yaml":
  the API version in the data (apps/v1beta1) does not match the expected API
  version (apps/v1)

We should try and use the canonical apiVersion for our test manifests, starting
with Deployments.

Fixes: #167