### PR TITLE
Lili/cloudwatch on delete

### DIFF
--- a/agent/cloudwatch.go
+++ b/agent/cloudwatch.go
@@ -18,6 +18,12 @@ import (
 	"github.com/weaveworks/launcher/pkg/text"
 )
 
+type cloudwatch struct {
+	Region     string
+	SecretName string
+	Resources  []string
+}
+
 // Watch for CM creation.
 func watchConfigMaps(cfg *agentConfig) {
 	source := cache.NewListWatchFromClient(

--- a/agent/main.go
+++ b/agent/main.go
@@ -39,7 +39,12 @@ const (
 		"&git-path={{.FluxConfig.GitPath}}&git-branch={{.FluxConfig.GitBranch}}" +
 		"{{end}}"
 	defaultCloudwatchURL = "https://{{.WCHostname}}/k8s/{{.KubernetesMajorMinorVersion}}/cloudwatch.yaml?" +
-		"aws-region={{.Region}}&aws-secret={{.SecretName}}&aws-resources={{.Resources}}"
+		"aws-region={{.Region}}" +
+		"&aws-secret={{.SecretName}}" +
+		"&aws-resources={{.Resources}}" +
+		"&aws-config={{.ConfigName}}" +
+		"&aws-config-uid={{.ConfigUID}}" +
+		"&aws-secret-uid={{.SecretUID}}"
 )
 
 type agentConfig struct {

--- a/agent/main.go
+++ b/agent/main.go
@@ -66,12 +66,6 @@ type agentConfig struct {
 	SecretInformer cache.SharedIndexInformer
 }
 
-type cloudwatch struct {
-	Region     string
-	SecretName string
-	Resources  []string
-}
-
 var validResources = []string{"rds", "classic-elb"}
 
 func init() {


### PR DESCRIPTION
We pass Secrets and CM name and UID to cloudwatch URL, to include
ownerReferences in the generated manifest file, and by that adding the
ability for kubernetes to remove the cloudwatch deployed resources
whenever the user deletes the cm and secret.

Closes #219