### PR TITLE
Add cloudwatch e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,32 @@ jobs:
             kubectl get events --all-namespaces --field-selector=type=Warning
           when: on_fail
 
+  integration_cloudwatch:
+    machine: true
+    environment:
+      CHANGE_MINIKUBE_NONE_USER: true
+    working_directory: ~/.go_workspace/src/github.com/weaveworks/launcher
+    steps:
+      - checkout
+      - run: make dep
+      - <<: *integration_deps
+      - <<: *start_minikube
+      - <<: *wait_for_k8s
+      - run:
+          name: Execute integration tests
+          no_output_timeout: 10m
+          environment:
+            GOPATH: /home/circleci/.go_workspace
+          command: |
+            if [ -z "${CIRCLE_TAG}" -a "${CIRCLE_BRANCH}" == "master" ]; then
+              export SERVICE_IMAGE="quay.io/weaveworks/launcher-service:$(docker/image-tag)"
+            else
+              export SERVICE_IMAGE=quay.io/weaveworks/build-tmp-public:launcher-service-$(docker/image-tag)
+            fi
+            ./integration-tests/tests/e2e.sh
+            go test -v ./integration-tests/e2e -args -log.verbose
+      - <<: *failed_test
+
   integration_kube_system_migration:
     machine: true
     environment:
@@ -265,6 +291,11 @@ workflows:
       - bootstrap
       - service
       - integration_install_update_flow:
+          requires:
+            - agent
+            - bootstrap
+            - service
+      - integration_cloudwatch:
           requires:
             - agent
             - bootstrap

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -56,6 +56,14 @@
   version = "v3.1.0"
 
 [[projects]]
+  name = "github.com/dlespiau/kube-harness"
+  packages = [
+    ".",
+    "logger"
+  ]
+  revision = "ef7a1e1ed84733511a999798dc7918bb2461e164"
+
+[[projects]]
   branch = "master"
   name = "github.com/docker/distribution"
   packages = [
@@ -488,6 +496,12 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/sync"
+  packages = ["errgroup"]
+  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -778,6 +792,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "05112b81083734a0da388b3ea8699db148ccf24eb465fc6df3d2553ff7a6df47"
+  inputs-digest = "654d70c56c833eed37e748573742bb0627769d86d10c7d2bb97e60b42a37ff17"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,6 @@
 #   go-tests = true
 #   unused-packages = true
 
-
 [[constraint]]
   name = "github.com/jessevdk/go-flags"
   version = "1.3.0"
@@ -45,11 +44,11 @@
   branch = "master"
   name = "github.com/weaveworks/common"
 
-[[constraint]]
+[[override]]
   name = "k8s.io/client-go"
   version = "v6.0.0"
 
-[[constraint]]
+[[override]]
   name = "k8s.io/apimachinery"
   branch = "release-1.9"
 
@@ -88,3 +87,8 @@ branch = "release-1.9"
 [[constraint]]
   name = "github.com/prometheus/client_golang"
   version = "v0.9.0-pre1"
+
+[[constraint]]
+  name = "github.com/dlespiau/kube-harness"
+  revision = "ef7a1e1ed84733511a999798dc7918bb2461e164"
+

--- a/integration-tests/e2e/cloudwatch_test.go
+++ b/integration-tests/e2e/cloudwatch_test.go
@@ -1,0 +1,41 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+const (
+	ns                       = "weave"
+	timeout                  = 5 * time.Minute
+	cloudwatchDeploymentName = "cloudwatch-exporter"
+	cloudwatchCMName         = "weave-cloudwatch-exporter-config"
+)
+
+// TestClouwatchResourceCreation tests that by creating a user cloudwatch
+// ConfigMap and Secret cloudwatch specific resources are deployed by the agent.
+func TestClouwatchResourceCreating(t *testing.T) {
+	test := kube.NewTest(t).Setup()
+	defer test.Close()
+
+	// Create Secret
+	secret := test.CreateSecretFromFile(ns, "cloudwatch-secret.yaml")
+
+	// Create ConfigMap
+	cm := test.CreateConfigMapFromFile(ns, "cloudwatch-cm.yaml")
+
+	// Wait for the above resources to be created.
+	test.WaitForSecretReady(secret, timeout)
+	test.WaitForConfigMapReady(cm, timeout)
+
+	// Make sure that the Cloudwatch deployment with name 'cloudwatch-exporter' in 'weave' ns exists.
+	_, err := test.GetDeployment(ns, cloudwatchDeploymentName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make sure that the cloudwatch cm with name 'weave-cloudwatch-exporter-config' in 'weave' ns exists
+	_, err = test.GetConfigMap(ns, cloudwatchCMName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/integration-tests/e2e/main_test.go
+++ b/integration-tests/e2e/main_test.go
@@ -1,0 +1,48 @@
+package e2e
+
+import (
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dlespiau/kube-harness"
+	"github.com/dlespiau/kube-harness/logger"
+)
+
+var kube *harness.Harness
+
+func manifestDirectory() string {
+	wd, _ := os.Getwd()
+	return filepath.Join(wd, "resources")
+}
+
+func TestMain(m *testing.M) {
+	kubeconfig := flag.String("kubeconfig", "", "kube config path, e.g. $HOME/.kube/config")
+	verbose := flag.Bool("log.verbose", false, "turn on more verbose logging")
+	//tag := flag.String("image-tag", "", "tag of docker images to test")
+	flag.Parse()
+
+	options := harness.Options{
+		Kubeconfig:        *kubeconfig,
+		ManifestDirectory: manifestDirectory(),
+	}
+	if *verbose {
+		options.LogLevel = logger.Debug
+	}
+	kube = harness.New(options)
+
+	if err := kube.Setup(); err != nil {
+		log.Printf("failed to initialize test harness: %v\n", err)
+	}
+
+	code := kube.Run(m)
+
+	if err := kube.Close(); err != nil {
+		log.Printf("failed to teardown test harness: %v\n", err)
+		code = 1
+	}
+
+	os.Exit(code)
+}

--- a/integration-tests/e2e/resources/cloudwatch-cm.yaml
+++ b/integration-tests/e2e/resources/cloudwatch-cm.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap 
+metadata:
+  name: cloudwatch
+  namespace: weave
+data:
+  cloudwatch.yaml: |
+    ---
+    region: us-east-1
+    secretName: cloudwatch
+    resources:
+      - rds

--- a/integration-tests/e2e/resources/cloudwatch-secret.yaml
+++ b/integration-tests/e2e/resources/cloudwatch-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudwatch
+  namespace: weave
+type: Opaque
+data:
+  access-key-id: RTNMWUE=
+  secret-access-key: RGZoSHg=

--- a/integration-tests/tests/e2e.sh
+++ b/integration-tests/tests/e2e.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+tests_root=$(dirname "$0")/..
+
+. ${tests_root}/common.sh
+
+echo "• Install agents in kube-system"
+k8s_kube_system_yaml=${tests_root}/k8s/k8s-kube-system.yaml
+templatinator "config.sh" $k8s_kube_system_yaml
+kubectl apply -f $k8s_kube_system_yaml -n kube-system
+
+echo "• Set WEAVE_CLOUD_TOKEN if it is not already set"
+[ -z "$WEAVE_CLOUD_TOKEN" ] && WEAVE_CLOUD_TOKEN="abcd1234"
+
+echo "• Start launcher/service on minikube"
+service_yaml=${tests_root}/k8s/service.yaml
+templatinator "config.sh" $service_yaml
+kubectl apply -f $service_yaml
+
+wait_for_service
+
+echo "• Install Weave Cloud on the minikube cluster"
+curl -Ls $(minikube service service --url) | sh -s -- --token=${WEAVE_CLOUD_TOKEN} --assume-yes
+
+wait_for_wc_agents
+


### PR DESCRIPTION
First step towards having all the e2e tests in go! 🎉 

Closes https://github.com/weaveworks/launcher/issues/228

Note: Decided to just add a creation test, as the deletion one took a really long time around 5-10 minutes to delete all the resources, not sure if the benefits are there for that?