### PR TITLE
circle-ci: Wait for actual kube-dns pod to be ready

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
             # Wait for nodes to become ready
             JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
             # Wait for DNS to be ready
-            sleep 30
+            JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods -n kube-system; done
       - run:
           name: Execute integration tests
           no_output_timeout: 2m


### PR DESCRIPTION
We can also say this closes https://github.com/weaveworks/launcher/issues/199, as so far all the failure with DNS on launcher were strictly due to kube-dns not being ready. 