### PR TITLE
Output logs on failed DNS check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ jobs:
           command: |
             kubectl get all --all-namespaces
             kubectl get events --all-namespaces --field-selector=type=Warning
+            kubectl logs -n weave -l=launcher=dns
           when: on_fail
 
   integration_cloudwatch:

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -262,7 +262,7 @@ func TestDNS(c Client, domain string) (bool, error) {
 	}
 
 	// Create pod to perform nslookup on a passed domain to check DNS is working.
-	_, err = Execute(c, "run", "-n", "weave", "--image", "busybox", "--restart=Never", "--command", podName, "nslookup", domain)
+	_, err = Execute(c, "run", "-n", "weave", "--image", "busybox", "--labels=launcher=dns", "--restart=Never", "--command", podName, "nslookup", domain)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
We often see failures of DNS preflight check, but do not know the
details of the failures.