### PR TITLE
tests: Remove output so tests can timeout

### DIFF
--- a/integration-tests/setup/reset-local-minikube.sh
+++ b/integration-tests/setup/reset-local-minikube.sh
@@ -25,7 +25,7 @@ kubectl delete svc nginx-bootstrap 2> /dev/null
 
 echo "• Wait for terminating pods"
 JSONPATH='{range .items[*]}{@.metadata.name}{end}'
-while [ $(kubectl get pods -l name=service -o jsonpath="$JSONPATH" 2>&1 | wc -c | tr -d '[:space:]') != 0 ]; do echo -n .; sleep 1; done
-while [ $(kubectl get pods -n weave -o jsonpath="$JSONPATH" 2>&1 | wc -c | tr -d '[:space:]') != 0 ]; do echo -n .; sleep 1; done
+while [ $(kubectl get pods -l name=service -o jsonpath="$JSONPATH" 2>&1 | wc -c | tr -d '[:space:]') != 0 ]; do sleep 1; done
+while [ $(kubectl get pods -n weave -o jsonpath="$JSONPATH" 2>&1 | wc -c | tr -d '[:space:]') != 0 ]; do sleep 1; done
 
 exit 0

--- a/integration-tests/setup/setup-local-minikube.sh
+++ b/integration-tests/setup/setup-local-minikube.sh
@@ -34,4 +34,4 @@ kubectl apply -f $bootstrap_yaml
 
 ###
 echo -n "• Waiting for nginx-bootstrap service to be available"
-until curl -Ls $(minikube service nginx-bootstrap --url) >/dev/null 2>/dev/null; do echo -n .; sleep 1; done
+until curl -Ls $(minikube service nginx-bootstrap --url) >/dev/null 2>/dev/null; do sleep 1; done

--- a/integration-tests/tests/flux-config.sh
+++ b/integration-tests/tests/flux-config.sh
@@ -43,7 +43,7 @@ kubectl apply -f "https://cloud.weave.works/k8s/flux.yaml?t=${WEAVE_CLOUD_TOKEN}
 
 echo "• Wait for weave-flux-agent to become ready"
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
-until kubectl get pods -n weave -l name=weave-flux-agent -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do echo -n .; sleep 1; done
+until kubectl get pods -n weave -l name=weave-flux-agent -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
 echo "• Install Weave Cloud"
 curl -Ls $(minikube service service --url) | sh -s -- --token=${WEAVE_CLOUD_TOKEN} --assume-yes

--- a/integration-tests/tests/install-update-flow.sh
+++ b/integration-tests/tests/install-update-flow.sh
@@ -61,10 +61,10 @@ run_self_update_test () {
     kubectl delete pod -n weave -l name=weave-agent
 
     echo "• Wait for the agent to start the self update"
-    while [ $(kubectl get pods --no-headers -n weave -l name=weave-agent | wc -l | tr -d '[:space:]') = 1 ] ; do echo -n .; sleep 1; done
+    while [ $(kubectl get pods --no-headers -n weave -l name=weave-agent | wc -l | tr -d '[:space:]') = 1 ] ; do sleep 1; done
 
     echo "• Wait for the agent to finish the self update"
-    until [ $(kubectl get pods --no-headers -n weave -l name=weave-agent | wc -l | tr -d '[:space:]') = 1 ] ; do echo -n .; sleep 1; done
+    until [ $(kubectl get pods --no-headers -n weave -l name=weave-agent | wc -l | tr -d '[:space:]') = 1 ] ; do sleep 1; done
 
     wait_for_wc_agents
 
@@ -103,14 +103,14 @@ run_self_update_failure_test () {
 
     echo "• Wait for the new agent to fail to pull the image"
     JSONPATH='{range .items[*]}{@.metadata.name}:{@.status.containerStatuses[*].state.waiting.reason}{end}'
-    until kubectl get pods -n weave -o jsonpath="$JSONPATH" 2>&1 | grep -q "ImagePullBackOff"; do echo -n .; sleep 1; done
+    until kubectl get pods -n weave -o jsonpath="$JSONPATH" 2>&1 | grep -q "ImagePullBackOff"; do sleep 1; done
 
     echo "• Wait for the agent to begin recovery"
     JSONPATH='{range .items[*]}{@.metadata.name}:{@.status.containerStatuses[*].state.waiting.reason}{end}'
-    while kubectl get pods -n weave -o jsonpath="$JSONPATH" 2>&1 | grep -q "ImagePullBackOff"; do echo -n .; sleep 1; done
+    while kubectl get pods -n weave -o jsonpath="$JSONPATH" 2>&1 | grep -q "ImagePullBackOff"; do sleep 1; done
 
     echo "• Wait for the agent to finish recovery"
-    until [ $(kubectl get pods --no-headers -n weave -l name=weave-agent | wc -l | tr -d '[:space:]') = 1 ] ; do echo -n .; sleep 1; done
+    until [ $(kubectl get pods --no-headers -n weave -l name=weave-agent | wc -l | tr -d '[:space:]') = 1 ] ; do sleep 1; done
 
     wait_for_wc_agents
 }

--- a/integration-tests/tests/kube-system-migration.sh
+++ b/integration-tests/tests/kube-system-migration.sh
@@ -30,7 +30,7 @@ wait_for_wc_agents
 
 echo "• Wait for kube-system agents to be removed"
 JSONPATH='{range .items[*]}{@.metadata.name}{end}'
-while [ $(kubectl get pods -n kube-system -l 'app in (weave-flux, weave-cortex, weave-scope)' -o jsonpath="$JSONPATH" 2>&1 | wc -c | tr -d '[:space:]') != 0 ]; do echo -n .; sleep 1; done
+while [ $(kubectl get pods -n kube-system -l 'app in (weave-flux, weave-cortex, weave-scope)' -o jsonpath="$JSONPATH" 2>&1 | wc -c | tr -d '[:space:]') != 0 ]; do sleep 1; done
 
 echo "• Check old flux arguments have been applied to the new agent"
 args=$(kubectl get pod -n weave -l name=weave-flux-agent -o jsonpath='{.items[?(@.metadata.labels.name=="weave-flux-agent")].spec.containers[?(@.name=="flux-agent")].args[*]}')


### PR DESCRIPTION
The output of '.' prevented the timeout to happen, instead we should
rely on the timeout we set in the circleci config.