### PR TITLE
Add cri endpoint detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: make dep
+      - run: make service/static/agent.yaml
       - run: go test ./service
       - run: make service
       - deploy:

--- a/agent/main.go
+++ b/agent/main.go
@@ -37,6 +37,9 @@ const (
 		"{{if .FluxConfig}}" +
 		"&git-label={{.FluxConfig.GitLabel}}&git-url={{.FluxConfig.GitURL}}" +
 		"&git-path={{.FluxConfig.GitPath}}&git-branch={{.FluxConfig.GitBranch}}" +
+		"{{end}}" +
+		"{{if .CRIEndpoint}}" +
+		"&cri-endpoint={{.CRIEndpoint}}" +
 		"{{end}}"
 	defaultCloudwatchURL = "https://{{.WCHostname}}/k8s/{{.KubernetesMajorMinorVersion}}/cloudwatch.yaml?" +
 		"aws-region={{.Region}}" +
@@ -61,6 +64,7 @@ type agentConfig struct {
 	KubeClient             *kubeclient.Clientset
 	KubectlClient          kubectl.Client
 	FluxConfig             *FluxConfig
+	CRIEndpoint            string
 
 	CMInformer     cache.SharedIndexInformer
 	SecretInformer cache.SharedIndexInformer
@@ -186,6 +190,7 @@ func mainImpl() {
 	agentRecoveryWait := flag.Duration("agent.recovery-wait", defaultAgentRecoveryWait, "Duration to wait before recovering from a failed self update")
 	reportErrors := flag.Bool("agent.report-errors", false, "Should the agent report errors to sentry")
 	address := flag.String("agent.address", ":8080", "agent HTTP address")
+	criEndpoint := flag.String("agent.cri-endpoint", "", "Container runtime endpoint of the Kubernetes cluster.")
 
 	wcToken := flag.String("wc.token", "", "Weave Cloud instance token")
 	wcPollInterval := flag.Duration("wc.poll-interval", 1*time.Hour, "Polling interval to check WC manifests")
@@ -216,6 +221,7 @@ func mainImpl() {
 		WCHostname:           *wcHostname,
 		AgentPollURLTemplate: *agentPollURLTemplate,
 		WCPollURLTemplate:    *wcPollURLTemplate,
+		CRIEndpoint:          *criEndpoint,
 	}
 	raven.SetTagsContext(map[string]string{
 		"weave_cloud_hostname": *wcHostname,

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -83,7 +83,9 @@ func mainImpl() {
 		if err != nil {
 			log.Fatal("error detecting container runtime endpoint: ", err)
 		}
-		fmt.Println("Detected container runtime endpoint:", opts.CRIEndpoint)
+		if opts.CRIEndpoint != "" {
+			fmt.Printf("Detected container runtime endpoint: %s. To override the container runtime endpoint set the '--cri-endpoint=<ENDPOINT>' flag.", opts.CRIEndpoint)
+		}
 	}
 
 	agentK8sURL, err := text.ResolveString(agentK8sURLTemplate, opts)

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -24,7 +24,10 @@ import (
 )
 
 const (
-	agentK8sURLTemplate = "{{.Scheme}}://{{.LauncherHostname}}/k8s/agent.yaml"
+	agentK8sURLTemplate = "{{.Scheme}}://{{.LauncherHostname}}/k8s/agent.yaml" +
+		"{{if .CRIEndpoint}}" +
+		"&cri-endpoint={{.CRIEndpoint}}" +
+		"{{end}}"
 )
 
 type options struct {
@@ -36,6 +39,7 @@ type options struct {
 	GKE              bool   `long:"gke" description:"Create clusterrolebinding for GKE instances"`
 	ReportErrors     bool   `long:"report-errors" description:"Should install errors be reported to sentry"`
 	SkipChecks       bool   `long:"skip-checks" description:"Skip pre-flight checks"`
+	CRIEndpoint      string `long:"cri-endpoint" description:"Set custom CRI container runtime endpoint. e.g.: 'unix:///var/run/crio/crio.sock'"`
 }
 
 func init() {

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -408,35 +408,35 @@ func GetSecretValue(c Client, namespace, name, key string) (string, error) {
 	return string(valueBytes), nil
 }
 
-type Nodes struct {
-	Items []NodeItems `json:"items"`
+type nodes struct {
+	Items []nodeItems `json:"items"`
 }
 
-type NodeItems struct {
-	Status NodeStatus `json:"status"`
+type nodeItems struct {
+	Status nodeStatus `json:"status"`
 }
 
-type NodeStatus struct {
+type nodeStatus struct {
 	NodeInfo map[string]string `json:"nodeInfo"`
 }
 
 // GetContainerRuntimeName returns the container runtime name the node uses.
 func GetContainerRuntimeName(c Client) (string, error) {
-	var nodes Nodes
-	err := ExecuteJSON(c, &nodes, "get", "nodes", "-owide")
+	var n nodes
+	err := ExecuteJSON(c, &n, "get", "nodes", "-owide")
 	if err != nil {
 		return "", err
 	}
 
 	// Pick the first node and match based on that.
 	// It is unlikely that different nodes would have different container runtimes.
-	containerRuntimeVersion := nodes.Items[0].Status.NodeInfo["containerRuntimeVersion"]
+	containerRuntimeVersion := n.Items[0].Status.NodeInfo["containerRuntimeVersion"]
 
 	// split version from name
 	containerRuntimeName := strings.Split(containerRuntimeVersion, "://")[0]
 
 	if containerRuntimeName == "" {
-		return "", fmt.Errorf("Could not fetch Container Runtime name information, it was empty.")
+		return "", fmt.Errorf("could not fetch Container Runtime name information as it was empty")
 	}
 
 	return containerRuntimeName, nil

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -91,8 +91,7 @@ func TestBootstrapHandler(t *testing.T) {
 func TestAgentYAMLHandler(t *testing.T) {
 	agentManifest := "---\napiVersion: extensions/v1beta1"
 	handlers := &Handlers{
-		bootstrapVersion:  "aaa000",
-		agentManifestData: []byte(agentManifest),
+		bootstrapVersion: "aaa000",
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(handlers.agentYAML))

--- a/service/static/agent.yaml.in
+++ b/service/static/agent.yaml.in
@@ -79,3 +79,4 @@ items:
               - -wc.hostname={{.WCHostname}}
               - -wc.token=$(WEAVE_CLOUD_TOKEN)
               - -agent.report-errors=true
+              - -agent.cri-endpoint={{.CRIEndpoint}}


### PR DESCRIPTION
Opening early so @dlespiau can base his work on the endpoint.
**DO NOT MERGE** until the complimentary PR is done in the generator.

We detect the CRI via the nodes command, and parse the CRI name and match that with the endpoint. Currently there is not good way of detecting the docker shim endpoint, as the name is always docker, but the user can always override their runtime with the `--cri-endpoint` flag.