### PR TITLE
agent: Pass cri-endpoint to agent manifest file

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -29,7 +29,10 @@ import (
 )
 
 const (
-	defaultAgentPollURL      = "https://get.weave.works/k8s/agent.yaml?instanceID={{.InstanceID}}"
+	defaultAgentPollURL = "https://get.weave.works/k8s/agent.yaml?instanceID={{.InstanceID}}" +
+		"{{if .CRIEndpoint}}" +
+		"&cri-endpoint={{.CRIEndpoint}}" +
+		"{{end}}"
 	defaultAgentRecoveryWait = 5 * time.Minute
 	defaultWCHostname        = "cloud.weave.works"
 	defaultWCPollURL         = "https://{{.WCHostname}}/k8s.yaml" +

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -84,7 +84,7 @@ func mainImpl() {
 			log.Fatal("error detecting container runtime endpoint: ", err)
 		}
 		if opts.CRIEndpoint != "" {
-			fmt.Printf("Detected container runtime endpoint: %s. To override the container runtime endpoint set the '--cri-endpoint=<ENDPOINT>' flag.", opts.CRIEndpoint)
+			fmt.Printf("Detected container runtime endpoint: %s. To override the container runtime endpoint set the '--cri-endpoint=<ENDPOINT>' flag.\n", opts.CRIEndpoint)
 		}
 	}
 


### PR DESCRIPTION
After update, we always "lost" the information about `cri-endpoint`.

Closes: https://github.com/weaveworks/launcher/issues/256