### PR TITLE
agent: Correctly encode the new GET parameters

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -98,7 +98,7 @@ func logError(msg string, err error, cfg *agentConfig) {
 	}
 }
 
-func agentManifestURL(template string, cfg *agentConfig) string {
+func agentManifestURL(cfg *agentConfig) string {
 	agentPollURL, err := text.ResolveString(cfg.AgentPollURLTemplate, cfg)
 	if err != nil {
 		log.Fatal("invalid URL template: ", err)
@@ -122,7 +122,7 @@ func agentManifestURL(template string, cfg *agentConfig) string {
 
 func updateAgents(cfg *agentConfig, cancel <-chan interface{}) {
 	// Self-update
-	agentPollURL := agentManifestURL(cfg.AgentPollURLTemplate, cfg)
+	agentPollURL := agentManifestURL(cfg)
 	log.Info("Updating self from ", agentPollURL)
 
 	initialRevision, err := k8s.GetLatestDeploymentReplicaSetRevision(cfg.KubeClient, "weave", "weave-agent")

--- a/agent/main.go
+++ b/agent/main.go
@@ -114,7 +114,9 @@ func agentManifestURL(cfg *agentConfig) string {
 		q := url.Query()
 		q.Add("cri-endpoint", cfg.CRIEndpoint)
 
+		url.RawQuery = q.Encode()
 		agentPollURL = url.String()
+
 	}
 
 	return agentPollURL

--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"errors"
+	"net/url"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetMinorMajorVersion(t *testing.T) {
@@ -37,4 +40,17 @@ func TestGetMinorMajorVersion(t *testing.T) {
 			t.Errorf("Version was wrongl expected: %s got %s", c.version, v)
 		}
 	}
+}
+
+func TestAgentManifestURL(t *testing.T) {
+	cfg := &agentConfig{
+		AgentPollURLTemplate: "https://get.weave.works/k8s/agent.yaml",
+		CRIEndpoint:          "/foo/bar",
+	}
+
+	manifestURL := agentManifestURL(cfg)
+	v := url.Values{
+		"cri-endpoint": []string{"/foo/bar"},
+	}
+	assert.Contains(t, manifestURL, v.Encode())
 }


### PR DESCRIPTION
I thought the library would do it for me, but no. The URL struct only has the `WawQuery` field and String() compute the URL string with that field.
    
To add a GET parameter we need to encode the RawQuery manually.
    
This time, I unit-tested it, that's the price to pay when not getting right the first time!
