### PR TITLE
Provide a read-only option to the installer

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -98,6 +98,19 @@ func logError(msg string, err error, cfg *agentConfig) {
 	}
 }
 
+func addParameter(baseURL, param, value string) string {
+	url, err := url.Parse(baseURL)
+	if err != nil {
+		log.Fatal("couldn't parse URL: ", baseURL, err)
+	}
+
+	q := url.Query()
+	q.Add(param, value)
+
+	url.RawQuery = q.Encode()
+	return url.String()
+}
+
 func agentManifestURL(cfg *agentConfig) string {
 	agentPollURL, err := text.ResolveString(cfg.AgentPollURLTemplate, cfg)
 	if err != nil {
@@ -106,16 +119,7 @@ func agentManifestURL(cfg *agentConfig) string {
 
 	// Propagate the cri-endpoint to service.
 	if cfg.CRIEndpoint != "" {
-		url, err := url.Parse(agentPollURL)
-		if err != nil {
-			log.Fatal("couldn't parse agent URL: ", err)
-		}
-
-		q := url.Query()
-		q.Add("cri-endpoint", cfg.CRIEndpoint)
-
-		url.RawQuery = q.Encode()
-		agentPollURL = url.String()
+		agentPollURL = addParameter(agentPollURL, "cri-endpoint", cfg.CRIEndpoint)
 
 	}
 

--- a/agent/main.go
+++ b/agent/main.go
@@ -33,7 +33,8 @@ const (
 	defaultAgentPollURL = "https://get.weave.works/k8s/agent.yaml?instanceID={{.InstanceID}}" +
 		"{{if .CRIEndpoint}}" +
 		"&cri-endpoint={{.CRIEndpoint}}" +
-		"{{end}}"
+		"{{end}}" +
+		"&read-only={{.ReadOnly}}"
 	defaultAgentRecoveryWait = 5 * time.Minute
 	defaultWCHostname        = "cloud.weave.works"
 	defaultWCPollURL         = "https://{{.WCHostname}}/k8s.yaml" +
@@ -44,7 +45,8 @@ const (
 		"{{end}}" +
 		"{{if .CRIEndpoint}}" +
 		"&cri-endpoint={{.CRIEndpoint}}" +
-		"{{end}}"
+		"{{end}}" +
+		"&read-only={{.ReadOnly}}"
 	defaultCloudwatchURL = "https://{{.WCHostname}}/k8s/{{.KubernetesMajorMinorVersion}}/cloudwatch.yaml?" +
 		"aws-region={{.Region}}" +
 		"&aws-secret={{.SecretName}}" +
@@ -69,6 +71,7 @@ type agentConfig struct {
 	KubectlClient          kubectl.Client
 	FluxConfig             *FluxConfig
 	CRIEndpoint            string
+	ReadOnly               bool
 
 	CMInformer     cache.SharedIndexInformer
 	SecretInformer cache.SharedIndexInformer
@@ -120,7 +123,11 @@ func agentManifestURL(cfg *agentConfig) string {
 	// Propagate the cri-endpoint to service.
 	if cfg.CRIEndpoint != "" {
 		agentPollURL = addParameter(agentPollURL, "cri-endpoint", cfg.CRIEndpoint)
+	}
 
+	// Propagate the read-only to service.
+	if cfg.ReadOnly {
+		agentPollURL = addParameter(agentPollURL, "read-only", "true")
 	}
 
 	return agentPollURL
@@ -220,6 +227,7 @@ func mainImpl() {
 	reportErrors := flag.Bool("agent.report-errors", false, "Should the agent report errors to sentry")
 	address := flag.String("agent.address", ":8080", "agent HTTP address")
 	criEndpoint := flag.String("agent.cri-endpoint", "", "Container runtime endpoint of the Kubernetes cluster.")
+	readOnly := flag.Bool("agent.read-only", false, "Disable scope controls")
 
 	wcToken := flag.String("wc.token", "", "Weave Cloud instance token")
 	wcPollInterval := flag.Duration("wc.poll-interval", 1*time.Hour, "Polling interval to check WC manifests")
@@ -251,6 +259,7 @@ func mainImpl() {
 		AgentPollURLTemplate: *agentPollURLTemplate,
 		WCPollURLTemplate:    *wcPollURLTemplate,
 		CRIEndpoint:          *criEndpoint,
+		ReadOnly:             *readOnly,
 	}
 	raven.SetTagsContext(map[string]string{
 		"weave_cloud_hostname": *wcHostname,

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/blang/semver"
 	raven "github.com/getsentry/raven-go"
-
 	"github.com/jessevdk/go-flags"
 	"github.com/weaveworks/launcher/pkg/gcloud"
 	"github.com/weaveworks/launcher/pkg/kubectl"
@@ -24,7 +23,8 @@ import (
 )
 
 const (
-	agentK8sURLTemplate = "{{.Scheme}}://{{.LauncherHostname}}/k8s/agent.yaml"
+	agentK8sURLTemplate = "{{.Scheme}}://{{.LauncherHostname}}/k8s/agent.yaml" +
+		"{{if .ReadOnly}}?read-only=true{{end}}"
 )
 
 type options struct {
@@ -36,6 +36,7 @@ type options struct {
 	GKE              bool   `long:"gke" description:"Create clusterrolebinding for GKE instances"`
 	ReportErrors     bool   `long:"report-errors" description:"Should install errors be reported to sentry"`
 	SkipChecks       bool   `long:"skip-checks" description:"Skip pre-flight checks"`
+	ReadOnly         bool   `long:"read-only" description:"Disallow scope controls"`
 }
 
 func init() {

--- a/service/main.go
+++ b/service/main.go
@@ -24,6 +24,7 @@ type templateData struct {
 	LauncherHostname string
 	WCHostname       string
 	CRIEndpoint      string
+	ReadOnly         bool
 }
 
 var (
@@ -121,8 +122,17 @@ func (h *Handlers) bootstrap(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, fmt.Sprintf("%s/bootstrap/%s/%s", *bootstrapBaseURL, h.bootstrapVersion, filename), 301)
 }
 
+func boolFromParam(r *http.Request, param string) bool {
+	v := r.URL.Query().Get(param)
+	if v == "true" {
+		return true
+	}
+	return false
+}
+
 func (h *Handlers) agentYAML(w http.ResponseWriter, r *http.Request) {
 	h.templateData.CRIEndpoint = r.URL.Query().Get("cri-endpoint")
+	h.templateData.ReadOnly = boolFromParam(r, "read-only")
 	agentManifestData, err := loadData(*agentManifest, h.templateData)
 	if err != nil {
 		log.Fatal("error reading agentYAMLFile:", err)

--- a/service/static/agent.yaml.in
+++ b/service/static/agent.yaml.in
@@ -80,3 +80,4 @@ items:
               - -wc.token=$(WEAVE_CLOUD_TOKEN)
               - -agent.report-errors=true
               - -agent.cri-endpoint={{.CRIEndpoint}}
+              - -agent.read-only={{.ReadOnly}}


### PR DESCRIPTION
 Users may want to disable scope controls as they allow creating shells in containers, including the privileged containers. Add an option to prevent that.

The flow is a bit intricate, but that's the same one we have the `cri-endpoint` parameter.
- give the `--read-only` option to the installer (script)
- script forward option to bootstrap binary
- bootstrap uses it to ask for the agent manifest to the service through a URL Get parameter
- service serves an agent manifest with the `read-only` option
- agent uses that option to both:
  - auto-updates: agent query service for agent manifests
  - scope installs: agent uses the `read-only` parameter of the launch-generator to get the corresponding scope manifest.

While what we really want is going to a CRD with the various weave cloud options as described in https://github.com/weaveworks/launcher/issues/245#issuecomment-409268010, it's a bit of work to get there. The read-only option may become ` read-only: true` in the CRD at some point. At least we have a migration path: bootstrap will directly forge the right CRD with the option given and agent will consult the CRD to know what to do.