### PR TITLE
ci: Run apt-get update before install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - deploy:
           name: Push binaries to S3
           command: |
+            sudo apt-get update
             sudo apt-get -y -qq install awscli
             aws s3 cp build/bootstrap/ s3://weaveworks-launcher/bootstrap/${CIRCLE_SHA1}/ --recursive
 


### PR DESCRIPTION
Currently fails with:

```
sudo apt-get -y -qq install awscli
aws s3 cp build/bootstrap/ s3://weaveworks-launcher/bootstrap/${CIRCLE_SHA1}/ --recursive
E: Failed to fetch http://deb.debian.org/debian/pool/main/p/python3.5/libpython3.5-minimal_3.5.3-1_amd64.deb  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/pool/main/p/python3.5/python3.5-minimal_3.5.3-1_amd64.deb  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/pool/main/p/python3.5/libpython3.5-stdlib_3.5.3-1_amd64.deb  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/pool/main/p/python3.5/python3.5_3.5.3-1_amd64.deb  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/pool/main/l/lcms2/liblcms2-2_2.8-4_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Exited with code 100
```