### PR TITLE
Expand on the recognised fluxd flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Start by setting up a minikube instance to run the tests on:
 
 Run the tests:
 ```
-make integration-tests
+make
+make integration-tests WEAVE_CLOUD_TOKEN=<YOUR_TEST_INSTANCE_ON_FRONTEND.DEV.WEAVE.WORKS>
 ```
 
 This script will first ensure the dependencies are built and then run:

--- a/agent/flux.go
+++ b/agent/flux.go
@@ -6,43 +6,43 @@ import (
 	"strings"
 	"time"
 
-	flags "github.com/jessevdk/go-flags"
+	"github.com/spf13/pflag"
 	"github.com/weaveworks/launcher/pkg/kubectl"
 )
 
 // FluxConfig stores existing flux arguments which will be used when updating WC agents
 type FluxConfig struct {
 	// git parameters
-	GitLabel *string `long:"git-label"`
-	GitURL   *string `long:"git-url"`
+	GitLabel *string
+	GitURL   *string
 	// This arg is multi-valued, or can be passed as comma-separated
 	// values. This accounts for either form.
-	GitPath         []string       `long:"git-path"`
-	GitBranch       *string        `long:"git-branch"`
-	GitTimeout      *time.Duration `long:"git-timeout"`
-	GitPollInterval *time.Duration `long:"git-poll-interval"`
-	GitSetAuthor    *bool          `long:"git-set-author"`
-	GitCISkip       *bool          `long:"git-ci-skip"`
+	GitPath         []string
+	GitBranch       *string
+	GitTimeout      *time.Duration
+	GitPollInterval *time.Duration
+	GitSetAuthor    *bool
+	GitCISkip       *bool
 
 	// sync behaviour
-	GarbageCollection *bool `long:"sync-garbage-collection"`
+	GarbageCollection *bool
 
 	// For specifying ECR region from outside AWS (fluxd detects it when inside AWS)
-	RegistryECRRegion []string `long:"registry-ecr-region"`
+	RegistryECRRegion []string
 	// For requiring a particular registry to be accessible, else crash
-	RegistryRequire []string `long:"registry-require"`
+	RegistryRequire []string
 	// Can be used to switch image registry scanning off for some or
 	// all images (with glob patterns)
-	RegistryExcludeImage []string `long:"registry-exclude-image"`
+	RegistryExcludeImage []string
 
 	// This is now hard-wired to empty in launch-generator, to tell flux
 	// _not_ to use service discovery. But: maybe someone needs to use
 	// service discovery.
-	MemcachedService *string `long:"memcached-service"`
+	MemcachedService *string
 
 	// Just in case we more explicitly support restricting Weave
 	// Cloud, or just Flux to particular namespaces
-	AllowNamespace []string `long:"k8s-allow-namepace"`
+	AllowNamespace []string
 }
 
 // AsQueryParams returns the configuration as a fragment of query
@@ -50,6 +50,10 @@ type FluxConfig struct {
 func (c *FluxConfig) AsQueryParams() string {
 	// Nothing clever here.
 	vals := url.Values{}
+
+	if c == nil {
+		return ""
+	}
 
 	// String-valued arguments
 	for arg, val := range map[string]*string{
@@ -99,22 +103,90 @@ func (c *FluxConfig) AsQueryParams() string {
 	return vals.Encode()
 }
 
+func isFlagPassed(fs *pflag.FlagSet, name string) bool {
+	found := false
+	fs.Visit(func(f *pflag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
+}
+
+// ParseFluxArgs parses a string of args into a nice FluxConfig
+func ParseFluxArgs(argString string) (*FluxConfig, error) {
+	cfg := &FluxConfig{}
+
+	fs := pflag.NewFlagSet("default", pflag.ContinueOnError)
+	fs.ParseErrorsWhitelist.UnknownFlags = true
+
+	// strings
+	cfg.GitLabel = fs.String("git-label", "", "")
+	cfg.GitURL = fs.String("git-url", "", "")
+	cfg.GitBranch = fs.String("git-branch", "", "")
+	cfg.MemcachedService = fs.String("memcached-service", "", "")
+
+	// durations
+	cfg.GitTimeout = fs.Duration("git-timeout", time.Second, "")
+	cfg.GitPollInterval = fs.Duration("git-poll-interval", time.Minute, "")
+
+	// bools
+	cfg.GitSetAuthor = fs.Bool("git-set-author", false, "")
+	cfg.GitCISkip = fs.Bool("git-ci-skip", false, "")
+	cfg.GarbageCollection = fs.Bool("sync-garbage-collection", false, "")
+
+	// string slices
+	fs.StringSliceVar(&cfg.GitPath, "git-path", nil, "")
+	fs.StringSliceVar(&cfg.RegistryECRRegion, "registry-ecr-region", nil, "")
+	fs.StringSliceVar(&cfg.RegistryRequire, "registry-require", nil, "")
+	fs.StringSliceVar(&cfg.RegistryExcludeImage, "registry-exclude-image", nil, "")
+	fs.StringSliceVar(&cfg.AllowNamespace, "k8s-allow-namespace", nil, "")
+
+	// Parse it all
+	fs.Parse(strings.Split(argString, " "))
+
+	// Cleanup anything that wasn't explicitly set
+	for arg, val := range map[string]**string{
+		"git-label":         &cfg.GitLabel,
+		"git-url":           &cfg.GitURL,
+		"git-branch":        &cfg.GitBranch,
+		"memcached-service": &cfg.MemcachedService,
+	} {
+		if !isFlagPassed(fs, arg) {
+			*val = nil
+		}
+	}
+	for arg, val := range map[string]**time.Duration{
+		"git-timeout":       &cfg.GitTimeout,
+		"git-poll-interval": &cfg.GitPollInterval,
+	} {
+		if !isFlagPassed(fs, arg) {
+			*val = nil
+		}
+	}
+	for arg, val := range map[string]**bool{
+		"sync-garbage-collection": &cfg.GarbageCollection,
+		"git-set-author":          &cfg.GitSetAuthor,
+		"git-ci-skip":             &cfg.GitCISkip,
+	} {
+		if !isFlagPassed(fs, arg) {
+			*val = nil
+		}
+	}
+
+	// Did we find anything?
+	if cfg.AsQueryParams() == "" {
+		return nil, nil
+	}
+
+	return cfg, nil
+}
+
 func getFluxConfig(k kubectl.Client, namespace string) (*FluxConfig, error) {
 	out, err := k.Execute("get", "pod", "-n", namespace, "-l", "name=weave-flux-agent", "-o", "jsonpath='{.items[?(@.metadata.labels.name==\"weave-flux-agent\")].spec.containers[0].args[*]}'")
 	if err != nil {
 		return nil, err
 	}
 
-	cfg := &FluxConfig{}
-	parser := flags.NewParser(cfg, flags.IgnoreUnknown)
-	_, err = parser.ParseArgs(strings.Split(out, " "))
-	if err != nil {
-		return nil, err
-	}
-
-	if cfg.AsQueryParams() == "" {
-		return nil, nil
-	}
-
-	return cfg, nil
+	return ParseFluxArgs(out)
 }

--- a/agent/flux.go
+++ b/agent/flux.go
@@ -112,5 +112,9 @@ func getFluxConfig(k kubectl.Client, namespace string) (*FluxConfig, error) {
 		return nil, err
 	}
 
+	if cfg.AsQueryParams() == "" {
+		return nil, nil
+	}
+
 	return cfg, nil
 }

--- a/agent/flux.go
+++ b/agent/flux.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	flags "github.com/jessevdk/go-flags"
 	"github.com/weaveworks/launcher/pkg/kubectl"
@@ -9,10 +12,91 @@ import (
 
 // FluxConfig stores existing flux arguments which will be used when updating WC agents
 type FluxConfig struct {
-	GitLabel  string `long:"git-label"`
-	GitURL    string `long:"git-url"`
-	GitPath   string `long:"git-path"`
-	GitBranch string `long:"git-branch"`
+	// git parameters
+	GitLabel *string `long:"git-label"`
+	GitURL   *string `long:"git-url"`
+	// This arg is multi-valued, or can be passed as comma-separated
+	// values. This accounts for either form.
+	GitPath         []string       `long:"git-path"`
+	GitBranch       *string        `long:"git-branch"`
+	GitTimeout      *time.Duration `long:"git-timeout"`
+	GitPollInterval *time.Duration `long:"git-poll-interval"`
+	GitSetAuthor    *bool          `long:"git-set-author"`
+	GitCISkip       *bool          `long:"git-ci-skip"`
+
+	// sync behaviour
+	GarbageCollection *bool `long:"sync-garbage-collection"`
+
+	// For specifying ECR region from outside AWS (fluxd detects it when inside AWS)
+	RegistryECRRegion []string `long:"registry-ecr-region"`
+	// For requiring a particular registry to be accessible, else crash
+	RegistryRequire []string `long:"registry-require"`
+	// Can be used to switch image registry scanning off for some or
+	// all images (with glob patterns)
+	RegistryExcludeImage []string `long:"registry-exclude-image"`
+
+	// This is now hard-wired to empty in launch-generator, to tell flux
+	// _not_ to use service discovery. But: maybe someone needs to use
+	// service discovery.
+	MemcachedService *string `long:"memcached-service"`
+
+	// Just in case we more explicitly support restricting Weave
+	// Cloud, or just Flux to particular namespaces
+	AllowNamespace []string `long:"k8s-allow-namepace"`
+}
+
+// AsQueryParams returns the configuration as a fragment of query
+// string, so it can be interpolated into a text template.
+func (c *FluxConfig) AsQueryParams() string {
+	// Nothing clever here.
+	vals := url.Values{}
+
+	// String-valued arguments
+	for arg, val := range map[string]*string{
+		"git-label":         c.GitLabel,
+		"git-url":           c.GitURL,
+		"git-branch":        c.GitBranch,
+		"memcached-service": c.MemcachedService,
+	} {
+		if val != nil {
+			vals.Add(arg, *val)
+		}
+	}
+
+	// []string-valued arguments
+	for arg, slice := range map[string][]string{
+		"git-path":               c.GitPath,
+		"registry-ecr-region":    c.RegistryECRRegion,
+		"registry-require":       c.RegistryRequire,
+		"registry-exclude-image": c.RegistryExcludeImage,
+		"k8s-allow-namespace":    c.AllowNamespace,
+	} {
+		for _, val := range slice {
+			vals.Add(arg, val)
+		}
+	}
+
+	// duration-valued arguments
+	for arg, dur := range map[string]*time.Duration{
+		"git-timeout":       c.GitTimeout,
+		"git-poll-interval": c.GitPollInterval,
+	} {
+		if dur != nil {
+			vals.Add(arg, dur.String())
+		}
+	}
+
+	for arg, flag := range map[string]*bool{
+		"sync-garbage-collection": c.GarbageCollection,
+		"git-set-author":          c.GitSetAuthor,
+		"git-ci-skip":             c.GitCISkip,
+	} {
+		if flag != nil {
+			vals.Add(arg, strconv.FormatBool(*flag))
+		}
+	}
+
+	return vals.Encode()
 }
 
 func getFluxConfig(k kubectl.Client, namespace string) (*FluxConfig, error) {
@@ -26,10 +110,6 @@ func getFluxConfig(k kubectl.Client, namespace string) (*FluxConfig, error) {
 	_, err = parser.ParseArgs(strings.Split(out, " "))
 	if err != nil {
 		return nil, err
-	}
-
-	if cfg.GitBranch == "" && cfg.GitLabel == "" && cfg.GitPath == "" && cfg.GitURL == "" {
-		return nil, nil
 	}
 
 	return cfg, nil

--- a/agent/main.go
+++ b/agent/main.go
@@ -40,8 +40,7 @@ const (
 	defaultWCPollURL         = "https://{{.WCHostname}}/k8s.yaml" +
 		"?k8s-version={{.KubernetesVersion}}&t={{.Token}}&omit-support-info=true" +
 		"{{if .FluxConfig}}" +
-		"&git-label={{.FluxConfig.GitLabel}}&git-url={{.FluxConfig.GitURL}}" +
-		"&git-path={{.FluxConfig.GitPath}}&git-branch={{.FluxConfig.GitBranch}}" +
+		"&{{.FluxConfig.AsQueryParams}}" +
 		"{{end}}" +
 		"{{if .CRIEndpoint}}" +
 		"&cri-endpoint={{.CRIEndpoint}}" +

--- a/agent/main.go
+++ b/agent/main.go
@@ -39,9 +39,7 @@ const (
 	defaultWCHostname        = "cloud.weave.works"
 	defaultWCPollURL         = "https://{{.WCHostname}}/k8s.yaml" +
 		"?k8s-version={{.KubernetesVersion}}&t={{.Token}}&omit-support-info=true" +
-		"{{if .FluxConfig}}" +
-		"&{{.FluxConfig.AsQueryParams}}" +
-		"{{end}}" +
+		"{{if .FluxConfig.AsQueryParams}}&{{.FluxConfig.AsQueryParams}}{{end}}" +
 		"{{if .CRIEndpoint}}" +
 		"&cri-endpoint={{.CRIEndpoint}}" +
 		"{{end}}" +

--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -131,4 +131,10 @@ func TestParseFluxArgs(t *testing.T) {
 	fluxCfg, err = ParseFluxArgs(argString)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "git-path=zing", fluxCfg.AsQueryParams())
+
+	// Preserves empty values
+	argString = "--memcached-service="
+	fluxCfg, err = ParseFluxArgs(argString)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "memcached-service=", fluxCfg.AsQueryParams())
 }

--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -58,7 +58,7 @@ func TestAgentManifestURL(t *testing.T) {
 
 func TestAgentFluxURL(t *testing.T) {
 	// Not an exhaustive test; just representative
-	gitPath := []string{"config/helloworld"}
+	gitPath := []string{"config/helloworld", "config/hej-world"}
 	memcachedService := ""
 	gitCISkip := false
 	gitTimeout := 40 * time.Second

--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -37,7 +38,7 @@ func TestGetMinorMajorVersion(t *testing.T) {
 			return
 		}
 		if v != c.version {
-			t.Errorf("Version was wrongl expected: %s got %s", c.version, v)
+			t.Errorf("Version was wrong; expected: %s got %s", c.version, v)
 		}
 	}
 }
@@ -52,5 +53,36 @@ func TestAgentManifestURL(t *testing.T) {
 	v := url.Values{
 		"cri-endpoint": []string{"/foo/bar"},
 	}
+	assert.Contains(t, manifestURL, v.Encode())
+}
+
+func TestAgentFluxURL(t *testing.T) {
+	// Not an exhaustive test; just representative
+	gitPath := []string{"config/helloworld"}
+	memcachedService := ""
+	gitCISkip := false
+	gitTimeout := 40 * time.Second
+
+	fluxCfg := &FluxConfig{
+		GitPath:          gitPath,
+		MemcachedService: &memcachedService,
+		GitCISkip:        &gitCISkip,
+		GitTimeout:       &gitTimeout,
+	}
+
+	cfg := &agentConfig{
+		AgentPollURLTemplate: defaultWCPollURL,
+		FluxConfig:           fluxCfg,
+	}
+
+	manifestURL := agentManifestURL(cfg)
+
+	v := url.Values{
+		"git-path":          gitPath,
+		"memcached-service": []string{""},
+		"git-ci-skip":       []string{"false"},
+		"git-timeout":       []string{"40s"},
+	}
+
 	assert.Contains(t, manifestURL, v.Encode())
 }

--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -86,3 +86,53 @@ func TestAgentFluxURL(t *testing.T) {
 
 	assert.Contains(t, manifestURL, v.Encode())
 }
+
+func TestParseFluxArgs(t *testing.T) {
+	// nothing
+	argString := ""
+	fluxCfg, err := ParseFluxArgs(argString)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "", fluxCfg.AsQueryParams())
+
+	// Test handling boolean flags w/out `=true|false`
+	argString = "--git-ci-skip"
+	fluxCfg, err = ParseFluxArgs(argString)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, true, *fluxCfg.GitCISkip)
+
+	// Test handling boolean flags w `=true|false`
+	argString = "--git-ci-skip=true"
+	fluxCfg, err = ParseFluxArgs(argString)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, true, *fluxCfg.GitCISkip)
+
+	argString = "--git-ci-skip=false"
+	fluxCfg, err = ParseFluxArgs(argString)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, false, *fluxCfg.GitCISkip)
+
+	// Test we only serialize props that we provided
+	argString = "--git-label=foo --git-path=derp"
+	fluxCfg, err = ParseFluxArgs(argString)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "foo", *fluxCfg.GitLabel)
+	assert.Equal(t, "git-label=foo&git-path=derp", fluxCfg.AsQueryParams())
+
+	// string[]
+	argString = "--git-path=zing --git-path=derp"
+	fluxCfg, err = ParseFluxArgs(argString)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "git-path=zing&git-path=derp", fluxCfg.AsQueryParams())
+
+	// unknown
+	argString = "--token=derp"
+	fluxCfg, err = ParseFluxArgs(argString)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "", fluxCfg.AsQueryParams())
+
+	// some unknown
+	argString = "--git-path=zing --token=derp"
+	fluxCfg, err = ParseFluxArgs(argString)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "git-path=zing", fluxCfg.AsQueryParams())
+}

--- a/integration-tests/tests/flux-config.sh
+++ b/integration-tests/tests/flux-config.sh
@@ -55,7 +55,8 @@ sleep 40
 
 echo "• Check flux configuration still exists"
 args=$(kubectl get pod -n weave -l name=weave-flux-agent -o jsonpath='{.items[?(@.metadata.labels.name=="weave-flux-agent")].spec.containers[?(@.name=="flux-agent")].args[*]}')
-if [[ $args != *"--git-url=git@github.com:weaveworks/example --git-path=k8s/example --git-branch=example --git-label=example"* ]]; then
-    echo "Missing existing flux args"
+expected="--git-url=git@github.com:weaveworks/example --git-path=k8s/example --git-branch=example --git-label=example"
+if [[ $args != *"$expected"* ]]; then
+    echo "Missing existing flux args: \"$expected\" not found in \"$args\""
     exit 1
 fi

--- a/integration-tests/tests/kube-system-migration.sh
+++ b/integration-tests/tests/kube-system-migration.sh
@@ -35,6 +35,6 @@ while [ $(kubectl get pods -n kube-system -l 'app in (weave-flux, weave-cortex, 
 echo "• Check old flux arguments have been applied to the new agent"
 args=$(kubectl get pod -n weave -l name=weave-flux-agent -o jsonpath='{.items[?(@.metadata.labels.name=="weave-flux-agent")].spec.containers[?(@.name=="flux-agent")].args[*]}')
 if [[ $args != *"--git-url=git@github.com:weaveworks/example --git-path=k8s/example --git-branch=master --git-label=example"* ]]; then
-    echo "Missing existing flux args"
+    echo "Missing existing flux args: $args"
     exit 1
 fi

--- a/integration-tests/tests/kube-system-migration.sh
+++ b/integration-tests/tests/kube-system-migration.sh
@@ -35,6 +35,6 @@ while [ $(kubectl get pods -n kube-system -l 'app in (weave-flux, weave-cortex, 
 echo "• Check old flux arguments have been applied to the new agent"
 args=$(kubectl get pod -n weave -l name=weave-flux-agent -o jsonpath='{.items[?(@.metadata.labels.name=="weave-flux-agent")].spec.containers[?(@.name=="flux-agent")].args[*]}')
 if [[ $args != *"--git-url=git@github.com:weaveworks/example --git-path=k8s/example --git-branch=master --git-label=example"* ]]; then
-    echo "Missing existing flux args: $args"
+    echo "Missing existing flux args: got $args"
     exit 1
 fi

--- a/service/static/install.sh
+++ b/service/static/install.sh
@@ -50,8 +50,9 @@ else
 fi
 
 # Download the bootstrap binary
-echo "Downloading the Weave Cloud installer...  "
-curl -Ls "{{.Scheme}}://{{.LauncherHostname}}/bootstrap?dist=$dist" >> "$TMPFILE"
+installerurl="{{.Scheme}}://{{.LauncherHostname}}/bootstrap?dist=$dist"
+echo "Downloading the Weave Cloud installer from $installerurl"
+curl -Ls "$installerurl" >> "$TMPFILE"
 
 # Make the bootstrap binary executable
 chmod +x "$TMPFILE"


### PR DESCRIPTION
This adds to the list of fluxd flags that the agent will recognise and include in launch-generator URLs.

Since there are now more than four, and they don't all appear together necessarily, I've changed how the URL is constructed.

Fixes #277. (And needs a compensating change in the service being polled for configs.)