### PR TITLE
Upgrades pflag to 1.0.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -437,8 +437,8 @@
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
 
 [[projects]]
   name = "github.com/stretchr/testify"


### PR DESCRIPTION
- Allows us to ignore extra, undefined args if we want to, which we do
  want to for parsing fluxd's arg list out of a k8s manifest