### PR TITLE
Update deployment API version to apps/v1beta1

### DIFF
--- a/service/static/agent.yaml.in
+++ b/service/static/agent.yaml.in
@@ -42,7 +42,7 @@ items:
       - kind: ServiceAccount
         name: weave-agent
         namespace: weave
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1beta1
     kind: Deployment
     metadata:
       name: weave-agent


### PR DESCRIPTION
The extensions API has been removed from Kubernetes 1.13+ and our installer fails on newer clusters