### PR TITLE
Switch to alpine for dns lookup tests

### DIFF
--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -262,7 +262,7 @@ func TestDNS(c Client, domain string) (bool, error) {
 	}
 
 	// Create pod to perform nslookup on a passed domain to check DNS is working.
-	_, err = Execute(c, "run", "-n", "weave", "--image", "docker.io/busybox", "--labels=launcher=dns", "--restart=Never", "--command", podName, "nslookup", domain)
+	_, err = Execute(c, "run", "-n", "weave", "--image", "docker.io/alpine", "--labels=launcher=dns", "--restart=Never", "--command", podName, "nslookup", domain)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
- Works w/ the latests 1.14 k8s + minikube

Fixes https://github.com/weaveworks/launcher/issues/285