### PR TITLE
Improve Flux argument parsing

### DIFF
--- a/agent/flux.go
+++ b/agent/flux.go
@@ -143,7 +143,7 @@ func ParseFluxArgs(argString string) (*FluxConfig, error) {
 }
 
 func getFluxConfig(k kubectl.Client, namespace string) (*FluxConfig, error) {
-	out, err := k.Execute("get", "pod", "-n", namespace, "-l", "name=weave-flux-agent", "-o", "jsonpath='{.items[?(@.metadata.labels.name==\"weave-flux-agent\")].spec.containers[0].args[*]}'")
+	out, err := k.Execute("get", "deploy", "-n", namespace, "-l", "name=weave-flux-agent", "-o", "jsonpath='{.items[?(@.metadata.labels.name==\"weave-flux-agent\")].spec.template.spec.containers[0].args[*]}'")
 	if err != nil {
 		return nil, err
 	}

--- a/agent/flux.go
+++ b/agent/flux.go
@@ -77,7 +77,7 @@ func (c *FluxConfig) AsQueryParams() string {
 		"registry-exclude-image": c.RegistryExcludeImage,
 		"k8s-allow-namespace":    c.AllowNamespace,
 	} {
-		for _, val := range slice {
+		for _, val := range deduplicate(slice) {
 			vals.Add(arg, val)
 		}
 	}
@@ -149,4 +149,20 @@ func getFluxConfig(k kubectl.Client, namespace string) (*FluxConfig, error) {
 	}
 
 	return ParseFluxArgs(out)
+}
+
+func deduplicate(s []string) []string {
+	if len(s) <= 1 {
+		return s
+	}
+
+	res := []string{}
+	seen := make(map[string]bool)
+	for _, val := range s {
+		if _, ok := seen[val]; !ok {
+			res = append(res, val)
+			seen[val] = true
+		}
+	}
+	return res
 }

--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -120,6 +120,12 @@ func TestParseFluxArgs(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "git-path=zing&git-path=derp", fluxCfg.AsQueryParams())
 
+	// string[] with duplicates
+	argString = "--git-path=zing --git-path=derp --git-path=zing"
+	fluxCfg, err = ParseFluxArgs(argString)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "git-path=zing&git-path=derp", fluxCfg.AsQueryParams())
+
 	// unknown
 	argString = "--token=derp"
 	fluxCfg, err = ParseFluxArgs(argString)


### PR DESCRIPTION
This prevents the launcher from duplicating `[]string` arguments in some edge case scenarios.

- Dedupe `[]string` Flux args before building query
- Get Flux args from deployment instead of pods
