### PR TITLE
Disable k8s 1.16 test jobs for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ job_environment_v1_14_2: &job_environment_v1_14_2
     CHANGE_MINIKUBE_NONE_USER: true
     KUBE_SERVER_VERSION: echo v1.14.2
     KUBECTL_VERSION: echo v1.14.2
-    MINIKUBE_VERSION: echo latest
+    MINIKUBE_VERSION: echo v1.2.0
 
 job_environment_vstable: &job_environment_vstable
   environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,4 +465,4 @@ workflows:
   #     - integration_flux_config_vstable:
   #         <<: *workflow_job_defaults
   #     - integration_gke_vstable:
-          <<: *workflow_job_defaults
+  #         <<: *workflow_job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,16 +407,16 @@ workflows:
           <<: *workflow_job_defaults
 
       # vstable jobs
-      - integration_install_update_flow_vstable:
-          <<: *workflow_job_defaults
-      - integration_cloudwatch_vstable:
-          <<: *workflow_job_defaults
-      - integration_kube_system_migration_vstable:
-          <<: *workflow_job_defaults
-      - integration_flux_config_vstable:
-          <<: *workflow_job_defaults
-      - integration_gke_vstable:
-          <<: *workflow_job_defaults
+      # - integration_install_update_flow_vstable:
+      #     <<: *workflow_job_defaults
+      # - integration_cloudwatch_vstable:
+      #     <<: *workflow_job_defaults
+      # - integration_kube_system_migration_vstable:
+      #     <<: *workflow_job_defaults
+      # - integration_flux_config_vstable:
+      #     <<: *workflow_job_defaults
+      # - integration_gke_vstable:
+      #     <<: *workflow_job_defaults
 
       - sentry:
           filters:
@@ -436,33 +436,33 @@ workflows:
       - healthcheck_prod
       - healthcheck_dev_v1_14_2
       - healthcheck_prod_v1_14_2
-      - healthcheck_dev_vstable
-      - healthcheck_prod_vstable
+      # - healthcheck_dev_vstable
+      # - healthcheck_prod_vstable
 
   # re-run $stable jobs once a day as a new
   # version of kubernetes might have been released
-  stable_kubernetes_still_works:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - agent:
-          filters:
-            tags:
-              only: /[0-9]+(\.[0-9]+)*(-[a-z]+)?/
-      - bootstrap
-      - service
-      - integration_install_update_flow_vstable:
-          <<: *workflow_job_defaults
-      - integration_cloudwatch_vstable:
-          <<: *workflow_job_defaults
-      - integration_kube_system_migration_vstable:
-          <<: *workflow_job_defaults
-      - integration_flux_config_vstable:
-          <<: *workflow_job_defaults
-      - integration_gke_vstable:
+  # stable_kubernetes_still_works:
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 0 * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #   jobs:
+  #     - agent:
+  #         filters:
+  #           tags:
+  #             only: /[0-9]+(\.[0-9]+)*(-[a-z]+)?/
+  #     - bootstrap
+  #     - service
+  #     - integration_install_update_flow_vstable:
+  #         <<: *workflow_job_defaults
+  #     - integration_cloudwatch_vstable:
+  #         <<: *workflow_job_defaults
+  #     - integration_kube_system_migration_vstable:
+  #         <<: *workflow_job_defaults
+  #     - integration_flux_config_vstable:
+  #         <<: *workflow_job_defaults
+  #     - integration_gke_vstable:
           <<: *workflow_job_defaults


### PR DESCRIPTION
Also there are some funny issues w/ mk 1.3.x w/ the integration tests so back to 1.2.0

Proper fixes for 1.16 in https://github.com/weaveworks/launcher/pull/299