### PR TITLE
Support ARM/ARM64/AMD64 architectures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,85 @@
+name: build
+
+on: [push]
+
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    env:
+      REVISION: $(git rev-parse HEAD)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
+
+      - name: Login to GitHub Docker Registry
+        run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build Agent Container Image Non-Master
+        if: github.ref != 'refs/heads/master'
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --build-arg=REVISION=${{ env.REVISION }} \
+            --tag raspbernetes/launcher-agent:${{ github.sha }} \
+            -f docker/agent.Dockerfile \
+            . \
+            --push
+      - name: Build Agent Container Image Master
+        if: github.ref == 'refs/heads/master'
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --build-arg=REVISION=${{ env.REVISION }} \
+            --tag raspbernetes/launcher-agent:latest \
+            -f docker/agent.Dockerfile \
+            . \
+            --push
+  service:
+    runs-on: ubuntu-latest
+    env:
+      REVISION: $(git rev-parse HEAD)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
+
+      - name: Login to GitHub Docker Registry
+        run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build Service Container Image Non-Master
+        if: github.ref != 'refs/heads/master'
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --build-arg=REVISION=${{ env.REVISION }} \
+            --tag raspbernetes/launcher-service:${{ github.sha }} \
+            -f docker/service.Dockerfile \
+            . \
+            --push
+      - name: Build Service Container Image Master
+        if: github.ref == 'refs/heads/master'
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --build-arg=REVISION=${{ env.REVISION }} \
+            --tag raspbernetes/launcher-service:latest \
+            -f docker/service.Dockerfile \
+            . \
+            --push

--- a/docker/agent.Dockerfile
+++ b/docker/agent.Dockerfile
@@ -1,0 +1,36 @@
+FROM golang:1.13-alpine as build
+
+ARG TARGETPLATFORM
+
+ENV GO111MODULE=off \
+    CGO_ENABLED=0
+
+RUN apk add --no-cache git make bash curl binutils build-base
+
+WORKDIR /go/src/github.com/weaveworks/launcher
+
+RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
+    export GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) && \
+    GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3); export GOARM=${GOARM:1} && \
+    git clone --depth 1 https://github.com/xunholy/launcher.git . && make all
+
+FROM alpine:3.7
+
+ARG REVISION
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=build /go/src/github.com/weaveworks/launcher/build/agent /usr/bin/launcher-agent
+
+COPY --from=build /go/src/github.com/weaveworks/launcher/build/kubectl /usr/bin/kubectl
+
+ENTRYPOINT ["/usr/bin/launcher-agent"]
+
+CMD ["-help"]
+
+
+LABEL maintainer="Weaveworks <help@weave.works>" \
+    org.opencontainers.image.title="launcher-agent" \
+    org.opencontainers.image.source="https://github.com/weaveworks/launcher" \
+    org.opencontainers.image.revision="${REVISION}" \
+    org.opencontainers.image.vendor="Weaveworks"

--- a/docker/service.Dockerfile
+++ b/docker/service.Dockerfile
@@ -1,0 +1,39 @@
+FROM golang:1.13-alpine as build
+
+ARG TARGETPLATFORM
+
+ENV GO111MODULE=off \
+    CGO_ENABLED=0
+
+RUN apk add --no-cache git make bash curl binutils build-base
+
+WORKDIR /go/src/github.com/weaveworks/launcher
+
+RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
+    export GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) && \
+    GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3); export GOARM=${GOARM:1} && \
+    git clone --depth 1 https://github.com/xunholy/launcher.git . && make all
+
+FROM alpine:3.7
+
+ARG REVISION
+
+WORKDIR /
+
+COPY --from=build /go/src/github.com/weaveworks/launcher/build/service /launcher-service
+
+RUN mkdir static
+
+COPY --from=build /go/src/github.com/weaveworks/launcher/build/static/install.sh /static/
+
+COPY --from=build /go/src/github.com/weaveworks/launcher/build/static/agent.yaml /static/
+
+EXPOSE 80
+
+ENTRYPOINT ["/launcher-service", "--bootstrap-version=936c2cf3123d720b1357d95992d5c4b648be5a39"]
+
+LABEL maintainer="Weaveworks <help@weave.works>" \
+    org.opencontainers.image.title="launcher-service" \
+    org.opencontainers.image.source="https://github.com/weaveworks/launcher" \
+    org.opencontainers.image.revision="${REVISION}" \
+    org.opencontainers.image.vendor="Weaveworks"


### PR DESCRIPTION
Fixes:

- #309
- refactor Dockerfile names to maintain correct file type and IDE linting
- remove unnecessary for loops building different ARCHS
- remove hardcoded GOARCH and GOOS on go build
- encapsulate build process inside docker therefore no longer having to configure build dependencies on the local machine, however, it still allows for local development if you do not wish to use docker.

TODO:

- refactor image tags in GitHub actions workflow
- cleanup makefile & remove unnecessary functions

Suggestions:

- update go modules with go mod init and use Golang GO111MODULE=on to keep consistent with the latest best practices
- update Dockerfiles to cache dependencies go mod download (dependant on the previous suggestion)