### PR TITLE
Data Race during write to a combined buffer

### DIFF
--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -26,7 +26,7 @@ type status struct {
 // Client implements a kubectl client to execute commands
 type Client interface {
 	Execute(args ...string) (string, error)
-	ExecuteOutputMatrix(args ...string) (stdout, stderr, combined string, err error)
+	ExecuteOutputMatrix(args ...string) (stdout, stderr string, err error)
 }
 
 // Execute executes kubectl <args> and returns the combined stdout/err output.
@@ -124,7 +124,7 @@ func parseVersionOutput(stdout string) (clientVersion, serverVersion string, err
 // May return a value for the kubectl client version, despite also returning an error
 func GetVersionInfo(c Client) (string, string, error) {
 	// Capture stdout only (to ignore server reachability errors)
-	stdout, stderr, _, err := c.ExecuteOutputMatrix("version")
+	stdout, stderr, err := c.ExecuteOutputMatrix("version")
 	clientVersion, serverVersion, parseErr := parseVersionOutput(stdout)
 	// If the server is unreachable, we might have an error but parsable output
 	if parseErr != nil {

--- a/pkg/kubectl/kubectl_test.go
+++ b/pkg/kubectl/kubectl_test.go
@@ -27,9 +27,9 @@ func (t *TestClient) Execute(args ...string) (string, error) {
 	return "", fmt.Errorf("Missing response for %q", cmd)
 }
 
-func (t *TestClient) ExecuteOutputMatrix(args ...string) (stdout, stderr, combined string, err error) {
+func (t *TestClient) ExecuteOutputMatrix(args ...string) (stdout, stderr string, err error) {
 	stdout, err = Execute(t, args...)
-	return stdout, "", stdout, err
+	return stdout, "", err
 }
 
 func TestGetSecretValue(t *testing.T) {

--- a/pkg/kubectl/local_test.go
+++ b/pkg/kubectl/local_test.go
@@ -32,9 +32,8 @@ func ExampleLocalClient() {
 func TestOutputMatrix(t *testing.T) {
 	cmd := exec.Command("/bin/sh", "-c", "echo stdout; sleep 0.001; echo stderr >&2; sleep 0.001; echo stdout")
 
-	stdout, stderr, combined, err := outputMatrix(cmd)
+	stdout, stderr, err := outputMatrix(cmd)
 	assert.Equal(t, "stdout\nstdout\n", stdout)
 	assert.Equal(t, "stderr\n", stderr)
-	assert.Equal(t, "stdout\nstderr\nstdout\n", combined)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Fixes a data race occuring between two goroutines writing to the same
buffer via two multiwriters.

Fixes #308 and also weaveworks/eksctl issue #1876