### PR TITLE
Makefile: Copy things around less

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,7 @@ docker/Dockerfile.service: docker/Dockerfile.service.in Makefile
 	@sed -e 's/@@GIT_HASH@@/$(GIT_HASH)/g' < $< > $@.tmp && mv $@.tmp $@
 
 build/.%.done: docker/Dockerfile.%
-	mkdir -p ./build/docker/$*
-	cp -r $^ ./build/docker/$*/
-	${DOCKER} build --build-arg=revision=$(GIT_HASH) -t weaveworks/launcher-$* -t weaveworks/launcher-$*:$(IMAGE_TAG) -f build/docker/$*/Dockerfile.$* ./build/docker/$*
+	${DOCKER} build --build-arg=revision=$(GIT_HASH) -t weaveworks/launcher-$* -t weaveworks/launcher-$*:$(IMAGE_TAG) -f docker/Dockerfile.$* .
 	touch $@
 
 #
@@ -96,7 +94,7 @@ build/.bootstrap.done: bootstrap/*.go
 # Service
 #
 
-build/.service.done: build/service build/static
+build/.service.done: build/service service/static/* service/static/agent.yaml
 
 build/service: $(SERVICE_DEPS)
 build/service: service/*.go
@@ -112,11 +110,6 @@ service/static/agent.yaml: service/static/agent.yaml.in
 	else \
 		sed -e 's|@@IMAGE_URL@@|weaveworks/build-tmp-public:launcher-agent-$(IMAGE_TAG)|g' < $< > $@.tmp && mv $@.tmp $@; \
 	fi
-
-build/static: service/static/* service/static/agent.yaml
-	mkdir -p $@
-	cp $^ $@
-
 
 #
 # Local integration tests

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,7 +1,7 @@
 FROM alpine:3.7
 RUN apk add --no-cache ca-certificates
-COPY ./agent /usr/bin/launcher-agent
-COPY ./kubectl /usr/bin/kubectl
+COPY ./build/agent /usr/bin/launcher-agent
+COPY ./build/kubectl /usr/bin/kubectl
 ENTRYPOINT ["/usr/bin/launcher-agent"]
 CMD ["-help"]
 

--- a/docker/Dockerfile.service.in
+++ b/docker/Dockerfile.service.in
@@ -1,9 +1,9 @@
 FROM alpine:3.7
 WORKDIR /
-COPY service /launcher-service
+COPY build/service /launcher-service
 RUN mkdir static
-COPY static/install.sh /static/
-COPY static/agent.yaml /static/
+COPY service/static/install.sh /static/
+COPY service/static/agent.yaml /static/
 EXPOSE 80
 ENTRYPOINT ["/launcher-service", "--bootstrap-version=@@GIT_HASH@@"]
 


### PR DESCRIPTION
I want to build the binaries first, and then just run docker
build afterwards, outside the makefile, and have them work.

Before this, the step that ran docker build in the makefile also
copied files around. After this, it doesn't, and the dockerfile just
adds the files directly from where they were built.