### PR TITLE
build: Add ECR context to stable_kubernetes_still_works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,7 +459,9 @@ workflows:
             tags:
               only: /[0-9]+(\.[0-9]+)*(-[a-z]+)?/
       - bootstrap
-      - service
+      - service:
+          context:
+            - ecr_upload
       - integration_install_update_flow_vstable:
           <<: *workflow_job_defaults
       - integration_cloudwatch_vstable:


### PR DESCRIPTION
I broke it last week when I was rotating keys and moving this to a context - I
only put it back to one o the worklow jobs that needed it.