### PR TITLE
build: Add timeout to curl loops

### DIFF
--- a/integration-tests/common.sh
+++ b/integration-tests/common.sh
@@ -6,7 +6,7 @@ wait_for_service () {
     until kubectl get pods -l name=service -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
     echo "• Wait for launcher/service to be fully reachable"
-    until curl -Ls $(minikube service service --url) > /dev/null 2>/dev/null; do sleep 1; done
+    until curl -Ls -m1 $(minikube service service --url); do sleep 1; done
 }
 
 wait_for_wc_agents () {

--- a/integration-tests/setup/setup-local-minikube.sh
+++ b/integration-tests/setup/setup-local-minikube.sh
@@ -34,4 +34,4 @@ kubectl apply -f $bootstrap_yaml
 
 ###
 echo -n "• Waiting for nginx-bootstrap service to be available"
-until curl -Ls $(minikube service nginx-bootstrap --url) >/dev/null 2>/dev/null; do sleep 1; done
+until curl -Ls -m1 $(minikube service nginx-bootstrap --url) ; do sleep 1; done


### PR DESCRIPTION
If minikube were to return something rubbish, curl would still try to connect to
it - and it might wait for a reply for quite some time. It might be better to
back off and try again, which is why I've added a maximum 1 second request time.

Also removing the pipe all output to /dev/null - it won't normally print
anything (it's in quiet mode) but if we *were* to do something horribly wrong,
I would like to see it.