### PR TITLE
Actually use the k8s version we want to, fix fallout to make stable work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ job_environment_vstable: &job_environment_vstable
     CHANGE_MINIKUBE_NONE_USER: true
     KUBE_SERVER_VERSION: curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
     KUBECTL_VERSION: curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
-    MINIKUBE_VERSION: echo v1.8.2
+    MINIKUBE_VERSION: echo v1.23.0
 
 workflow_job_defaults: &workflow_job_defaults
   requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,62 +287,62 @@ jobs:
   # v1.14.2 jobs
 
   integration_kube_system_migration_v1_14_2:
-    <<: *integration_kube_system_migration
     <<: *job_environment_v1_14_2
+    <<: *integration_kube_system_migration
 
   integration_install_update_flow_v1_14_2:
-    <<: *integration_install_update_flow
     <<: *job_environment_v1_14_2
+    <<: *integration_install_update_flow
 
   integration_cloudwatch_v1_14_2:
-    <<: *integration_cloudwatch
     <<: *job_environment_v1_14_2
+    <<: *integration_cloudwatch
 
   integration_flux_config_v1_14_2:
-    <<: *integration_flux_config
     <<: *job_environment_v1_14_2
+    <<: *integration_flux_config
 
   integration_gke_v1_14_2:
-    <<: *integration_gke
     <<: *job_environment_v1_14_2
+    <<: *integration_gke
 
   healthcheck_dev_v1_14_2:
-    <<: *healthcheck_dev
     <<: *job_environment_v1_14_2
+    <<: *healthcheck_dev
 
   healthcheck_prod_v1_14_2:
-    <<: *healthcheck_prod
     <<: *job_environment_v1_14_2
+    <<: *healthcheck_prod
 
   # vstable jobs
 
   integration_kube_system_migration_vstable:
-    <<: *integration_kube_system_migration
     <<: *job_environment_vstable
+    <<: *integration_kube_system_migration
 
   integration_install_update_flow_vstable:
-    <<: *integration_install_update_flow
     <<: *job_environment_vstable
+    <<: *integration_install_update_flow
 
   integration_cloudwatch_vstable:
-    <<: *integration_cloudwatch
     <<: *job_environment_vstable
+    <<: *integration_cloudwatch
 
   integration_flux_config_vstable:
-    <<: *integration_flux_config
     <<: *job_environment_vstable
+    <<: *integration_flux_config
 
   integration_gke_vstable:
-    <<: *integration_gke
     <<: *job_environment_vstable
+    <<: *integration_gke
 
   healthcheck_dev_vstable:
-    <<: *healthcheck_dev
     <<: *job_environment_vstable
+    <<: *healthcheck_dev
 
   healthcheck_prod_vstable:
-    <<: *healthcheck_prod
     <<: *job_environment_vstable
+    <<: *healthcheck_prod
 
   sentry:
     <<: *defaults

--- a/integration-tests/k8s/k8s-kube-system.yaml.in
+++ b/integration-tests/k8s/k8s-kube-system.yaml.in
@@ -7,7 +7,7 @@ items:
       name: weave-flux
       labels:
         name: weave-flux
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       name: weave-flux
@@ -24,7 +24,7 @@ items:
           - '*'
         verbs:
           - '*'
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: weave-flux
@@ -153,7 +153,7 @@ items:
       name: weave-scope
       labels:
         name: weave-scope
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       name: weave-scope
@@ -170,7 +170,7 @@ items:
           - '*'
         verbs:
           - '*'
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: weave-scope
@@ -252,7 +252,7 @@ items:
       name: weave-cortex
       labels:
         name: weave-cortex
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       name: weave-cortex
@@ -269,7 +269,7 @@ items:
           - '*'
         verbs:
           - '*'
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: weave-cortex

--- a/service/static/agent.yaml.in
+++ b/service/static/agent.yaml.in
@@ -11,7 +11,7 @@ items:
     metadata:
       name: weave-agent
       namespace: weave
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       name: weave-agent
@@ -28,7 +28,7 @@ items:
           - '*'
         verbs:
           - '*'
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: weave-agent


### PR DESCRIPTION
This does three things:
* Fix deprecation that made weave cloud impossible to install on latest stable k8s. This new API namespace should work for any version 1.8+.
* Swap the order of the merge key things - `integration_install_update_flow` inherits 1.9, `job_environment_vstable` is supposed ot override it with latest stable. The way it was specified before didn't work though - in any recent build you can see 1.9 being printed like this, if you expand the right step:
![Screenshot from 2021-09-14 09-52-17](https://user-images.githubusercontent.com/1743/133227178-19d1942c-4a19-4ccd-8486-8424f3afa1f2.png)
With this change, it seems to work. For now? Maybe it works sometimes depending on the version of the yaml parser circleci has? I'm a bit nervous about it, but it seems to work - I'll replace it again in a bit.
* Use newer minikube for stable, because the old one failed.

This makes the build more reliable. By which I mean, the 1.9 steps are as unreliable as ever, but 1.14 and vstable should pass more reliably, now that they're testing what they're supposed to.