### PR TITLE
'master'->'main' in github action

### DIFF
--- a/.github/workflows/mirror-images.yaml
+++ b/.github/workflows/mirror-images.yaml
@@ -4,7 +4,7 @@ name: mirror images
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   mirror-images:


### PR DESCRIPTION
As 'main' is the name of the default branch, not master