### PR TITLE
Disable `/debug/pprof` endpoint on the service

### DIFF
--- a/service/main.go
+++ b/service/main.go
@@ -9,6 +9,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/weaveworks/common/server"
 	"github.com/weaveworks/launcher/pkg/text"
 )
@@ -36,7 +39,7 @@ var (
 	agentManifest    = flag.String("agent-manifest", defaultAgentManifest, "File used to load agent k8s")
 	serverCfg        = server.Config{
 		MetricsNamespace:        "service",
-		RegisterInstrumentation: true,
+		RegisterInstrumentation: false,
 	}
 )
 
@@ -76,6 +79,10 @@ func main() {
 	server.HTTP.HandleFunc("/", handlers.install).Methods("GET").Name("install")
 	server.HTTP.HandleFunc("/bootstrap", handlers.bootstrap).Methods("GET").Name("bootstrap")
 	server.HTTP.HandleFunc("/k8s/agent.yaml", handlers.agentYAML).Methods("GET").Name("agentYAML")
+	server.HTTP.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+		EnableOpenMetrics: true,
+	}))
+
 	server.Run()
 }
 


### PR DESCRIPTION
This endpoint should not be publicly visible. We disable it here by
switching `RegisterInstrumentation` to false and then manually adding
the `/metrics` endpoint back in. The rest of the metrics configuration
is handled by the server library so we can ignore that for the time
being.